### PR TITLE
Danish. Typos checked and corrected. (for libfm-qt and pcmanfm-qt)

### DIFF
--- a/libfm-qt/libfm-qt_da.ts
+++ b/libfm-qt/libfm-qt_da.ts
@@ -53,7 +53,7 @@
     <message>
         <location filename="../../app-chooser-dialog.ui" line="98"/>
         <source>Execute in terminal emulator</source>
-        <translation>Udfør i terminalemualtor</translation>
+        <translation>Udfør i terminalemulator</translation>
     </message>
     <message>
         <location filename="../../app-chooser-dialog.ui" line="109"/>
@@ -91,7 +91,7 @@
     <message>
         <location filename="../../edit-bookmarks.ui" line="102"/>
         <source>Use drag and drop to reorder the items</source>
-        <translation>Brug træk-og-slip for at arrangere bogmærkerne</translation>
+        <translation>Brug træk- og-slip for at arrangere bogmærkerne</translation>
     </message>
 </context>
 <context>
@@ -266,7 +266,7 @@
         <location filename="../../file-props.ui" line="542"/>
         <location filename="../../file-props.ui" line="594"/>
         <source>Execute</source>
-        <translation>Eksever</translation>
+        <translation>Eksekver</translation>
     </message>
     <message>
         <location filename="../../file-props.ui" line="603"/>
@@ -286,7 +286,7 @@
     <message>
         <location filename="../../file-props.ui" line="653"/>
         <source>Advanced Mode</source>
-        <translation>Advanceret...</translation>
+        <translation>Avanceret...</translation>
     </message>
 </context>
 <context>
@@ -364,7 +364,7 @@
     <message>
         <location filename="../../dndactionmenu.cpp" line="37"/>
         <source>Create symlink here</source>
-        <translation>LAv symbolsk lænke her</translation>
+        <translation>Lav symbolsk lænke her</translation>
     </message>
     <message>
         <location filename="../../dndactionmenu.cpp" line="39"/>
@@ -386,13 +386,13 @@
         <location filename="../../execfiledialog.cpp" line="39"/>
         <source>This text file &apos;%1&apos; seems to be an executable script.
 What do you want to do with it?</source>
-        <translation>Denne tekst fil &quot;%1&quot; er tilsyneladende et eksverbart skript. 
+        <translation>Denne tekstfil &quot;%1&quot; er tilsyneladende et eksekverbart script.
 Hvad vil du foretage med det?</translation>
     </message>
     <message>
         <location filename="../../execfiledialog.cpp" line="44"/>
         <source>This file &apos;%1&apos; is executable. Do you want to execute it?</source>
-        <translation>Filen &quot;%1&quot; er eksverbar. Vil du ekskvere den?</translation>
+        <translation>Filen &quot;%1&quot; er eksekverbar. Vil du eksekvere den?</translation>
     </message>
 </context>
 <context>
@@ -490,7 +490,7 @@ Hvad vil du foretage med det?</translation>
         <location filename="../../fileoperation.cpp" line="221"/>
         <source>Some files cannot be moved to trash can because the underlying file systems don&apos;t support this operation.
 Do you want to delete them instead?</source>
-        <translation>Nogle filer kan ikke smides i papirkurven, fordi det underliggende filsystem ikke understøtter denne funktion
+        <translation>Nogle filer kan ikke smides i papirkurven, fordi det underliggende filsystem ikke understøtter denne funktion.
 Vil du slette dem istedet?</translation>
     </message>
     <message>
@@ -633,7 +633,7 @@ Vil du slette dem istedet?</translation>
     <message>
         <location filename="../../filepropsdialog.cpp" line="425"/>
         <source>Do you want to recursively apply these changes to all files and sub-folders?</source>
-        <translation>Vil du anvende disse ændringer rekursivt på alle filer og undermappeer?</translation>
+        <translation>Vil du anvende disse ændringer rekursivt på alle filer og undermapper?</translation>
     </message>
 </context>
 <context>
@@ -811,7 +811,7 @@ Vil du slette dem istedet?</translation>
     <message>
         <location filename="../../placesmodel.cpp" line="71"/>
         <source>Applications</source>
-        <translation>Apllikationer</translation>
+        <translation>Applikationer</translation>
     </message>
     <message>
         <location filename="../../placesmodel.cpp" line="83"/>
@@ -898,7 +898,7 @@ Size: %2
 Modified: %3</source>
         <translation>Type: %1
 Størrelse: %2
-Sensest ændret: %3</translation>
+Senest ændret: %3</translation>
     </message>
     <message>
         <location filename="../../renamedialog.cpp" line="56"/>
@@ -959,7 +959,7 @@ Senset ændret: %2</translation>
     <message>
         <location filename="../../mount-operation-password.ui" line="58"/>
         <source>Connect as u&amp;ser:</source>
-        <translation>Forbind osm &amp;bruger:</translation>
+        <translation>Forbind som &amp;bruger:</translation>
     </message>
     <message>
         <location filename="../../mount-operation-password.ui" line="79"/>
@@ -1036,7 +1036,7 @@ Senset ændret: %2</translation>
     <message>
         <location filename="../../utilities.cpp" line="171"/>
         <source>Please enter a new folder name:</source>
-        <translation>Venligst indtsast et nyt mappenavn:</translation>
+        <translation>Venligst indtast et nyt mappenavn:</translation>
     </message>
     <message>
         <location filename="../../utilities.cpp" line="172"/>

--- a/pcmanfm-qt/pcmanfm-qt_da.ts
+++ b/pcmanfm-qt/pcmanfm-qt_da.ts
@@ -28,7 +28,7 @@
         <source>Programming:
 * Hong Jen Yee (PCMan) &lt;pcman.tw@gmail.com&gt;
 </source>
-        <translation>Programming:
+        <translation>Programmering:
 * Hong Jen Yee (PCMan) &lt;pcman.tw@gmail.com&gt;</translation>
     </message>
     <message>
@@ -89,7 +89,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.<
     <message>
         <location filename="../../autorun.ui" line="33"/>
         <source>&lt;b&gt;Removable medium is inserted&lt;/b&gt;</source>
-        <translation>&lt;b&gt;Flytbart medie er reigstreret&lt;/b&gt;</translation>
+        <translation>&lt;b&gt;Flytbart medie er registreret&lt;/b&gt;</translation>
     </message>
     <message>
         <location filename="../../autorun.ui" line="40"/>
@@ -127,7 +127,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.<
     <message>
         <location filename="../../desktop-folder.ui" line="36"/>
         <source>Image file</source>
-        <translation>Billedefil</translation>
+        <translation>Billedfil</translation>
     </message>
     <message>
         <location filename="../../desktop-folder.ui" line="42"/>
@@ -145,7 +145,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.<
     <message>
         <location filename="../../desktop-preferences.ui" line="14"/>
         <source>Desktop Preferences</source>
-        <translation>Skrivebordsindstilligner</translation>
+        <translation>Skrivebordsindstillinger</translation>
     </message>
     <message>
         <location filename="../../desktop-preferences.ui" line="30"/>
@@ -258,12 +258,12 @@ Et mellemrum er også reserverte for tre linjers tekst.</translation>
     <message>
         <location filename="../../desktop-preferences.ui" line="321"/>
         <source>Window Manager</source>
-        <translation>Vindueshåntering</translation>
+        <translation>Vindueshåndtering</translation>
     </message>
     <message>
         <location filename="../../desktop-preferences.ui" line="327"/>
         <source>Show menus provided by window managers when desktop is clicked</source>
-        <translation>Vis vindueshånterignens menuer  når man klikker på skrivebordet</translation>
+        <translation>Vis vindueshåndteringens menuer når man klikker på skrivebordet</translation>
     </message>
     <message>
         <location filename="../../desktop-preferences.ui" line="315"/>
@@ -648,7 +648,7 @@ Et mellemrum er også reserverte for tre linjers tekst.</translation>
     <message>
         <location filename="../../main-win.ui" line="614"/>
         <source>File &amp;Properties</source>
-        <translation>Fil&amp;Egenskaber</translation>
+        <translation>Fil&amp;egenskaber</translation>
     </message>
     <message>
         <location filename="../../main-win.ui" line="617"/>
@@ -658,7 +658,7 @@ Et mellemrum er også reserverte for tre linjers tekst.</translation>
     <message>
         <location filename="../../main-win.ui" line="622"/>
         <source>&amp;Folder Properties</source>
-        <translation>&amp;Mappeegenkaber</translation>
+        <translation>&amp;Mappeegenskaber</translation>
     </message>
     <message>
         <location filename="../../main-win.ui" line="651"/>
@@ -1170,7 +1170,7 @@ Et mellemrum er også reserverte for tre linjers tekst.</translation>
     <message>
         <location filename="../../preferences.ui" line="172"/>
         <source>Move deleted files to &quot;trash bin&quot; instead of erasing from disk.</source>
-        <translation>Flyt slettede filer til papirkurven istedet for at slette dem fra disken.</translation>
+        <translation>Flyt slettede filer til papirkurven i stedet for at slette dem fra disken.</translation>
     </message>
     <message>
         <location filename="../../preferences.ui" line="676"/>
@@ -1210,7 +1210,7 @@ Et mellemrum er også reserverte for tre linjers tekst.</translation>
     <message>
         <location filename="../../preferences.ui" line="179"/>
         <source>Erase files on removable media instead of &quot;trash can&quot; creation</source>
-        <translation>Slet filer på flytbare medier, istedet for at smide dem i papirkurven</translation>
+        <translation>Slet filer på flytbare medier, i stedet for at smide dem i papirkurven</translation>
     </message>
     <message>
         <location filename="../../preferences.ui" line="186"/>
@@ -1243,7 +1243,7 @@ Et mellemrum er også reserverte for tre linjers tekst.</translation>
     <message>
         <location filename="../../preferences.ui" line="313"/>
         <source>User interface</source>
-        <translation>Brugerfalde</translation>
+        <translation>Brugerflade</translation>
     </message>
     <message>
         <location filename="../../preferences.ui" line="326"/>
@@ -1253,7 +1253,7 @@ Et mellemrum er også reserverte for tre linjers tekst.</translation>
     <message>
         <location filename="../../preferences.ui" line="336"/>
         <source>Always show full file names</source>
-        <translation>Vis altid fulde filanavne</translation>
+        <translation>Vis altid fulde filnavne</translation>
     </message>
     <message>
         <location filename="../../preferences.ui" line="346"/>
@@ -1395,7 +1395,7 @@ over mappevisningen og ikke over det venstre panel.</translation>
     <message>
         <location filename="../../preferences.ui" line="739"/>
         <source>Close &amp;tab containing removable medium</source>
-        <translation>Luk &amp;faneblad med det flytbare medue</translation>
+        <translation>Luk &amp;faneblad med det flytbare medie</translation>
     </message>
     <message>
         <location filename="../../preferences.ui" line="746"/>
@@ -1437,7 +1437,7 @@ over mappevisningen og ikke over det venstre panel.</translation>
     <message>
         <location filename="../../preferences.ui" line="842"/>
         <source>Show only user defined templates in menu</source>
-        <translation>Vis kun bruigerdefinerede skabeloner i menuen</translation>
+        <translation>Vis kun brugerdefinerede skabeloner i menuen</translation>
     </message>
     <message>
         <location filename="../../preferences.ui" line="849"/>
@@ -1452,7 +1452,7 @@ over mappevisningen og ikke over det venstre panel.</translation>
     <message>
         <location filename="../../preferences.ui" line="319"/>
         <source>Use SI decimal prefixes instead of IEC binary prefixes</source>
-        <translation>Brug SI decimapræfik istedet fo IEC præfikser</translation>
+        <translation>Brug SI decimalpræfiks i stedet fo IEC præfiks</translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
Quite some typos and some grammar corrected. Still only for libfm-qt and pcman-qt. (I used da-aspell to check)
