### PR TITLE
fixed order of components in CMakeLists.txt

### DIFF
--- a/lxqt-admin/CMakeLists.txt
+++ b/lxqt-admin/CMakeLists.txt
@@ -6,5 +6,5 @@ option(WITH_LXQT_ADMIN_TIME "Build lxqt-admin-time translations" ON)
 option(WITH_LXQT_ADMIN_USER "Build lxqt-admin-user translations" ON)
 
 #components
-add_component(WITH_LXQT_ADMIN_USER lxqt-admin-time)
-add_component(WITH_LXQT_ADMIN_TIME lxqt-admin-user)
+add_component(WITH_LXQT_ADMIN_USER lxqt-admin-user)
+add_component(WITH_LXQT_ADMIN_TIME lxqt-admin-time)


### PR DESCRIPTION
fixes issue #98 to correctly disable the option we want to have disabled instead of the opposite one
