### PR TITLE
Fix HTML markups

### DIFF
--- a/lxqt-config/liblxqt-config-cursor/lxqt-config-cursor_zh_TW.ts
+++ b/lxqt-config/liblxqt-config-cursor/lxqt-config-cursor_zh_TW.ts
@@ -11,8 +11,7 @@
     <message>
         <location filename="../../../selectwnd.ui" line="20"/>
         <source>Select the cursor theme you want to use (hover preview to test cursor). &lt;b&gt;LXQt session needs restart after this change&lt;/b&gt;:</source>
-        <translation>選擇您喜歡的游標主題 (檢視來回移動來測試游標) 。
-&lt;b&gt;套用改變需要重新啟動LXQt會話&lt;/b&gt;:</translation>
+        <translation>選擇您喜歡的游標主題 (檢視來回移動來測試游標) 。&lt;br&gt;&lt;b&gt;套用改變需要重新啟動LXQt會話&lt;/b&gt;:</translation>
     </message>
     <message>
         <location filename="../../../selectwnd.ui" line="81"/>


### PR DESCRIPTION
For some reason I don't know, a new line breaks HTML markups. Use ```<br>``` instead.

Before:
![default](https://user-images.githubusercontent.com/1937689/35799746-b055ca26-0aa1-11e8-9bff-4829bc1f360b.png)
After
![default](https://user-images.githubusercontent.com/1937689/35799764-c97cfcea-0aa1-11e8-9c58-513f05450bca.png)

Tested command:
```
$ LANGUAGE=zh_TW.UTF-8 lxqt-config-appearance
```
Environment:
Arch Linux with Qt 5.10.0. All LXQt packages are built from latest git.