### PR TITLE
Revert clock remove

### DIFF
--- a/lxqt-panel/CMakeLists.txt
+++ b/lxqt-panel/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.0.2 FATAL_ERROR)
 
 project(lxqt-panel)
 
+option(WITH_LXQT_PANEL_CLOCK "Build lxqt-panel plugin-clock translations" ON)
 option(WITH_LXQT_PANEL_COLORPICKER "Build lxqt-panel plugin-colorpicker translations" ON)
 option(WITH_LXQT_PANEL_CPULOAD "Build lxqt-panel plugin-cpuload translations" ON)
 option(WITH_LXQT_PANEL_DESKTOPSWITCH "Build lxqt-panel plugin-desktopswitch translations" ON)
@@ -27,6 +28,7 @@ option(WITH_LXQT_PANEL_WORLDCLOCK "Build lxqt-panel plugin-worldclock translatio
 build_component("panel" "")
 
 #plugins
+build_sub_component(WITH_LXQT_PANEL_CLOCK plugin-clock clock)
 build_sub_component(WITH_LXQT_PANEL_COLORPICKER plugin-colorpicker colorpicker)
 build_sub_component(WITH_LXQT_PANEL_CPULOAD plugin-cpuload cpuload)
 build_sub_component(WITH_LXQT_PANEL_DESKTOPSWITCH plugin-desktopswitch desktopswitch)

--- a/lxqt-panel/plugin-clock/clock.ts
+++ b/lxqt-panel/plugin-clock/clock.ts
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="en_US">
+<context>
+    <name>FirstDayCombo</name>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="49"/>
+        <source>&lt;locale based&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClock</name>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="57"/>
+        <source>Date&amp;Time (clock) plugin is deprecated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="58"/>
+        <source>The &lt;strong&gt;clock&lt;/strong&gt; plugin is deprecated and will be removed in future version of LXQt. Consider replacing it with &lt;strong&gt;worldclock&lt;/strong&gt;.&lt;br/&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="60"/>
+        <source>don&apos;t show this again</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClockConfiguration</name>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="14"/>
+        <source>Clock Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="20"/>
+        <source>Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="26"/>
+        <source>&amp;Show seconds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="33"/>
+        <source>12 &amp;hour style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="40"/>
+        <source>&amp;Use UTC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="76"/>
+        <source>&amp;Do not show date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="86"/>
+        <source>Show date &amp;before time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="93"/>
+        <source>Show date &amp;after time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="100"/>
+        <source>Show date below time on new &amp;line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="107"/>
+        <source>First day of week in calendar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="124"/>
+        <source>Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="130"/>
+        <source>Auto&amp;rotate when the panel is vertical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="50"/>
+        <source>Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="59"/>
+        <source>Date &amp;format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Input custom date format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Interpreted sequences of date format are:
+
+d	the day as number without a leading zero (1 to 31)
+dd	the day as number with a leading zero (01 to 31)
+ddd	the abbreviated localized day name (e.g. &apos;Mon&apos; to &apos;Sun&apos;).
+dddd	the long localized day name (e.g. &apos;Monday&apos; to &apos;Sunday&apos;).
+M	the month as number without a leading zero (1-12)
+MM	the month as number with a leading zero (01-12)
+MMM	the abbreviated localized month name (e.g. &apos;Jan&apos; to &apos;Dec&apos;).
+MMMM	the long localized month name (e.g. &apos;January&apos; to &apos;December&apos;).
+yy	the year as two digit number (00-99)
+yyyy	the year as four digit number
+
+All other input characters will be treated as text.
+Any sequence of characters that are enclosed in single quotes (&apos;)
+will also be treated as text and not be used as an expression.
+
+
+Custom date format:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/lxqt-panel/plugin-clock/clock_ar.ts
+++ b/lxqt-panel/plugin-clock/clock_ar.ts
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ar">
+<context>
+    <name>FirstDayCombo</name>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="49"/>
+        <source>&lt;locale based&gt;</source>
+        <translation>&lt;حسب المحليّة&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClock</name>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="57"/>
+        <source>Date&amp;Time (clock) plugin is deprecated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="58"/>
+        <source>The &lt;strong&gt;clock&lt;/strong&gt; plugin is deprecated and will be removed in future version of LXQt. Consider replacing it with &lt;strong&gt;worldclock&lt;/strong&gt;.&lt;br/&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="60"/>
+        <source>don&apos;t show this again</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClockConfiguration</name>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="14"/>
+        <source>Clock Settings</source>
+        <translation>إعدادات السّاعة</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="20"/>
+        <source>Time</source>
+        <translation>الوقت</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="26"/>
+        <source>&amp;Show seconds</source>
+        <translation>أ&amp;ظهر الثّواني</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="33"/>
+        <source>12 &amp;hour style</source>
+        <translation>نمط 12 &amp;ساعة</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="40"/>
+        <source>&amp;Use UTC</source>
+        <translation>ا&amp;ستخدم التّوقيت العاليميّ UTC</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="76"/>
+        <source>&amp;Do not show date</source>
+        <translation>لا تعر&amp;ض التّاريخ</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="86"/>
+        <source>Show date &amp;before time</source>
+        <translation>أظهر التّاريخ &amp;قبل الوقت</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="93"/>
+        <source>Show date &amp;after time</source>
+        <translation>أظهر التّاريخ ب&amp;عد الوقت</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="100"/>
+        <source>Show date below time on new &amp;line</source>
+        <translation>أظهر التّاريخ أسفل الوقت في سطر &amp;جديد</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="107"/>
+        <source>First day of week in calendar</source>
+        <translation>أوّل يوم في الأسبوع</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="124"/>
+        <source>Orientation</source>
+        <translation>الاتّجاه</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="130"/>
+        <source>Auto&amp;rotate when the panel is vertical</source>
+        <translation>&amp;دوّر آليًّا إن كانت اللوحة رأسيّة</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="50"/>
+        <source>Date</source>
+        <translation>التّاريخ</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="59"/>
+        <source>Date &amp;format</source>
+        <translation>&amp;نسق التّاريخ</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Input custom date format</source>
+        <translation>إدخال نسق التّاريخ المخصّص</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Interpreted sequences of date format are:
+
+d	the day as number without a leading zero (1 to 31)
+dd	the day as number with a leading zero (01 to 31)
+ddd	the abbreviated localized day name (e.g. &apos;Mon&apos; to &apos;Sun&apos;).
+dddd	the long localized day name (e.g. &apos;Monday&apos; to &apos;Sunday&apos;).
+M	the month as number without a leading zero (1-12)
+MM	the month as number with a leading zero (01-12)
+MMM	the abbreviated localized month name (e.g. &apos;Jan&apos; to &apos;Dec&apos;).
+MMMM	the long localized month name (e.g. &apos;January&apos; to &apos;December&apos;).
+yy	the year as two digit number (00-99)
+yyyy	the year as four digit number
+
+All other input characters will be treated as text.
+Any sequence of characters that are enclosed in single quotes (&apos;)
+will also be treated as text and not be used as an expression.
+
+
+Custom date format:</source>
+        <translation>الرموز المعتمدة لنسق التّاريخ هي:
+
+d	اليوم كعدد بدون صفر بادئ (1 إلى 31)‏
+dd	اليوم كعدد مع صفر بادئ (01 إلى 31)‏
+ddd	الاسم الموطّن المختصر لليوم (مثلًا &apos;سبت&apos; إلى &apos;جمع&apos;).‏
+dddd	الاسم الموطّن الطّويل لليوم (مثلًا &apos;السّبت&apos; إلى &apos;الجمعة&apos;).‏
+M	الشّهر كعدد بدون صفر بادئ (1-12)‏
+MM	الشّهر كعدد مع صفر بادئ (01-12)‏
+MMM	الاسم الموطّن المختصر للشّهر (مثلًا &apos;ينا&apos; إلى &apos;ديس&apos;).‏
+MMMM	الاسم الموطّن الطّويل للشّهر (مثلًا &apos;يناير&apos; إلى &apos;ديسمبر&apos;).‏
+yy	العام كخانتين عشريّتين (00-99)‏
+yyyy	العام كأربع خانات عشريّة
+
+ستُعتبر كلّ المحارف الأخرى نصًّا عاديًّا.
+أيّة محارف موجودة داخل علامات اقتباس مفردة (&apos;)
+ستُعتبر أيضًا نصًّا عاديًّا ولن تُستخدم كتعبير.
+
+
+نسق التّاريخ المخصّص:</translation>
+    </message>
+</context>
+</TS>

--- a/lxqt-panel/plugin-clock/clock_ca.ts
+++ b/lxqt-panel/plugin-clock/clock_ca.ts
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ca">
+<context>
+    <name>FirstDayCombo</name>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="49"/>
+        <source>&lt;locale based&gt;</source>
+        <translation>&lt;basat amb la configuració regional&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClock</name>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="57"/>
+        <source>Date&amp;Time (clock) plugin is deprecated</source>
+        <translation>El connector Date&amp;Time (clock) és obsolet</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="58"/>
+        <source>The &lt;strong&gt;clock&lt;/strong&gt; plugin is deprecated and will be removed in future version of LXQt. Consider replacing it with &lt;strong&gt;worldclock&lt;/strong&gt;.&lt;br/&gt;</source>
+        <translation>El connector &lt;strong&gt;clock&lt;/strong&gt; és obsolet i s&apos;eliminarà en una versió futura de LXQt. Considereu substituir-lo amb &lt;strong&gt;worldclock&lt;/strong&gt;.&lt;br/&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="60"/>
+        <source>don&apos;t show this again</source>
+        <translation>no tornis a mostrar-ho</translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClockConfiguration</name>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="14"/>
+        <source>Clock Settings</source>
+        <translation>Ajusts del rellotge</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="20"/>
+        <source>Time</source>
+        <translation>Hora</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="26"/>
+        <source>&amp;Show seconds</source>
+        <translation>Mostra els &amp;segons</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="33"/>
+        <source>12 &amp;hour style</source>
+        <translation>Estil 12 &amp;hores</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="40"/>
+        <source>&amp;Use UTC</source>
+        <translation>&amp;Utilitza UTC</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="76"/>
+        <source>&amp;Do not show date</source>
+        <translation>No mostris la &amp;data</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="86"/>
+        <source>Show date &amp;before time</source>
+        <translation>Mostra la data a&amp;bans de l&apos;hora</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="93"/>
+        <source>Show date &amp;after time</source>
+        <translation>Mostra la d&amp;ata després de l&apos;hora</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="100"/>
+        <source>Show date below time on new &amp;line</source>
+        <translation>Mostra la data a continuació de l&apos;hora en una &amp;línia nova</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="107"/>
+        <source>First day of week in calendar</source>
+        <translation>Primer dia de la setmana al calendari</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="124"/>
+        <source>Orientation</source>
+        <translation>Orientació</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="130"/>
+        <source>Auto&amp;rotate when the panel is vertical</source>
+        <translation>Gi&amp;ra automàticament quan el plafó sigui vertical</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="50"/>
+        <source>Date</source>
+        <translation>Data</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="59"/>
+        <source>Date &amp;format</source>
+        <translation>&amp;Format de la data</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Input custom date format</source>
+        <translation>Entrada del format de data personalitzat</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Interpreted sequences of date format are:
+
+d	the day as number without a leading zero (1 to 31)
+dd	the day as number with a leading zero (01 to 31)
+ddd	the abbreviated localized day name (e.g. &apos;Mon&apos; to &apos;Sun&apos;).
+dddd	the long localized day name (e.g. &apos;Monday&apos; to &apos;Sunday&apos;).
+M	the month as number without a leading zero (1-12)
+MM	the month as number with a leading zero (01-12)
+MMM	the abbreviated localized month name (e.g. &apos;Jan&apos; to &apos;Dec&apos;).
+MMMM	the long localized month name (e.g. &apos;January&apos; to &apos;December&apos;).
+yy	the year as two digit number (00-99)
+yyyy	the year as four digit number
+
+All other input characters will be treated as text.
+Any sequence of characters that are enclosed in single quotes (&apos;)
+will also be treated as text and not be used as an expression.
+
+
+Custom date format:</source>
+        <translation>Les seqüències amb interpretació de formatació de la data són:
+
+d	el dia com a número sense zero a l&apos;esquerra (1 a 31)
+dd	el dia com a número amb un zero a l&apos;esquerra (01 a 31)
+ddd	el nom abreviat del dia de la configuració regional (p. ex. de &apos;dl.&apos; a &apos;dg.&apos;).
+dddd	el nom llarg del dia de la configuració regional (p. ex. de &apos;dilluns&apos; a &apos;diumenge&apos;).
+M	el mes com a número sense zero a l&apos;esquerra (1-12)
+MM	el mes com a número amb un zero a l&apos;esquerra (01-12)
+MMM	el nom abreviat del mes de la configuració regional (p. ex. de &apos;gen.&apos; a &apos;des.&apos;).
+MMMM	el nom llarg del mes de la configuració regional (p. ex. &apos;de gener&apos; a &apos;de desembre&apos;).
+yy	l&apos;any com a un número de dos dígits (00-99)
+yyyy	l&apos;any com a un número de quatre dígits
+
+Tots els altres caràcters d&apos;entrada es tractaran com a text.
+Qualsevol seqüència de caràcters que estigui delimitada amb (&apos;)
+cometes simples també es tractarà com a text i no s&apos;utilitzarà
+com a expressió
+
+
+Format personalitzat de la data:</translation>
+    </message>
+</context>
+</TS>

--- a/lxqt-panel/plugin-clock/clock_cs.ts
+++ b/lxqt-panel/plugin-clock/clock_cs.ts
@@ -1,0 +1,217 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="cs">
+<context>
+    <name>FirstDayCombo</name>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="49"/>
+        <source>&lt;locale based&gt;</source>
+        <translation>&lt;založeno na místním nastavení data&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClock</name>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="57"/>
+        <source>Date&amp;Time (clock) plugin is deprecated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="58"/>
+        <source>The &lt;strong&gt;clock&lt;/strong&gt; plugin is deprecated and will be removed in future version of LXQt. Consider replacing it with &lt;strong&gt;worldclock&lt;/strong&gt;.&lt;br/&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="60"/>
+        <source>don&apos;t show this again</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClockConfiguration</name>
+    <message>
+        <source>LXQt Clock Settings</source>
+        <translation type="vanished">Nastavení hodin</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="14"/>
+        <source>Clock Settings</source>
+        <translation>Nastavení hodin</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="20"/>
+        <source>Time</source>
+        <translation>Čas</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="26"/>
+        <source>&amp;Show seconds</source>
+        <translation>&amp;Ukázat sekundy</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="33"/>
+        <source>12 &amp;hour style</source>
+        <translation>12 &amp;hodinový styl</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="40"/>
+        <source>&amp;Use UTC</source>
+        <translation>&amp;Použít světový čas (UTC)</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="59"/>
+        <source>Date &amp;format</source>
+        <translation>&amp;Formát data</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="76"/>
+        <source>&amp;Do not show date</source>
+        <translation>&amp;Neukazovat datum</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="86"/>
+        <source>Show date &amp;before time</source>
+        <translation>Ukázat datum &amp;před časem</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="93"/>
+        <source>Show date &amp;after time</source>
+        <translation>Ukázat datum &amp;za časem</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="100"/>
+        <source>Show date below time on new &amp;line</source>
+        <translation>Ukázat datum pod časem na novém řá&amp;dku</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="107"/>
+        <source>First day of week in calendar</source>
+        <translation>První den týdne v kalendáři</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="124"/>
+        <source>Orientation</source>
+        <translation>Natočení</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="130"/>
+        <source>Auto&amp;rotate when the panel is vertical</source>
+        <translation>&amp;Natočit automaticky, když je panel svisle</translation>
+    </message>
+    <message>
+        <source>&amp;Font</source>
+        <translation type="vanished">&amp;Písmo</translation>
+    </message>
+    <message>
+        <source>Font</source>
+        <translation type="vanished">Písmo</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="50"/>
+        <source>Date</source>
+        <translation>Datum</translation>
+    </message>
+    <message>
+        <source>Show &amp;date</source>
+        <translation type="vanished">Ukázat &amp;datum</translation>
+    </message>
+    <message>
+        <source>D&amp;ate format</source>
+        <translation type="vanished">Formát d&amp;ata</translation>
+    </message>
+    <message>
+        <source>Fon&amp;t</source>
+        <translation type="vanished">Pí&amp;smo</translation>
+    </message>
+    <message>
+        <source>Show date in &amp;new line</source>
+        <translation type="vanished">Ukázat datum na &amp;novém řádku</translation>
+    </message>
+    <message>
+        <source>&amp;Use theme fonts</source>
+        <translation type="vanished">&amp;Použít písma motivu</translation>
+    </message>
+    <message>
+        <source>Time font</source>
+        <translation type="vanished">Písmo pro čas</translation>
+    </message>
+    <message>
+        <source>Date font</source>
+        <translation type="vanished">Písmo pro datum</translation>
+    </message>
+    <message>
+        <source>Ultra light</source>
+        <translation type="vanished">Hodně světlé</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="vanished">Světlé</translation>
+    </message>
+    <message>
+        <source>Ultra black</source>
+        <translation type="vanished">Hodně černé</translation>
+    </message>
+    <message>
+        <source>Black</source>
+        <translation type="vanished">Černé</translation>
+    </message>
+    <message>
+        <source>Bold</source>
+        <translation type="vanished">Tučné</translation>
+    </message>
+    <message>
+        <source>Demi bold</source>
+        <translation type="vanished">Polotučné</translation>
+    </message>
+    <message>
+        <source>Italic</source>
+        <translation type="vanished">Kurzíva</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Input custom date format</source>
+        <translation>Zadat vlastní formát data</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Interpreted sequences of date format are:
+
+d	the day as number without a leading zero (1 to 31)
+dd	the day as number with a leading zero (01 to 31)
+ddd	the abbreviated localized day name (e.g. &apos;Mon&apos; to &apos;Sun&apos;).
+dddd	the long localized day name (e.g. &apos;Monday&apos; to &apos;Sunday&apos;).
+M	the month as number without a leading zero (1-12)
+MM	the month as number with a leading zero (01-12)
+MMM	the abbreviated localized month name (e.g. &apos;Jan&apos; to &apos;Dec&apos;).
+MMMM	the long localized month name (e.g. &apos;January&apos; to &apos;December&apos;).
+yy	the year as two digit number (00-99)
+yyyy	the year as four digit number
+
+All other input characters will be treated as text.
+Any sequence of characters that are enclosed in single quotes (&apos;)
+will also be treated as text and not be used as an expression.
+
+
+Custom date format:</source>
+        <translation>Vykládané posloupnosti formátu data jsou:
+
+d	den jako číslo bez nuly na začátku (1 až 31).
+dd	den jako číslo s nulou na začátku (01 až 31).
+ddd	zkrácený název dne (např. Po až Ne).
+dddd	dlouhý název dne (např Pondělí až Neděle).
+M	měsíc jako číslo bez nuly na začátku (1-12).
+MM	měsíc jako číslo s nulou na začátku (01-12).
+MMM	zkrácený název měsíce (např. Led až Pro).
+MMMM	dlouhý název měsíce (např. Leden až Prosinec).
+yy	rok jako číslo ze dvou číslic (00-99).
+yyyy	rok jako číslo ze čtyř číslic
+
+Se všemi ostatními zadanými znaky se bude zacházet jako s textem.
+Se všemi ostatními znakovými posloupnostmi uzavřenými v jednoduchých závorkách (&apos;)
+se bude stejně tak zacházet jako s textem a nebudou se používat jako výraz.
+
+
+Vlastní formát data:</translation>
+    </message>
+</context>
+</TS>

--- a/lxqt-panel/plugin-clock/clock_da.ts
+++ b/lxqt-panel/plugin-clock/clock_da.ts
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="da">
+<context>
+    <name>FirstDayCombo</name>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="49"/>
+        <source>&lt;locale based&gt;</source>
+        <translation>&lt;baseret på sprogvalg&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClock</name>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="57"/>
+        <source>Date&amp;Time (clock) plugin is deprecated</source>
+        <translation>Dato og klokkeslæt-pluginet (ur) er udgået</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="58"/>
+        <source>The &lt;strong&gt;clock&lt;/strong&gt; plugin is deprecated and will be removed in future version of LXQt. Consider replacing it with &lt;strong&gt;worldclock&lt;/strong&gt;.&lt;br/&gt;</source>
+        <translation>&lt;strong&gt;Ur&lt;/strong&gt;-pluginet er udgået og vil blive fjernet i fremtidige versioner af LXQt. Overvej at erstatte det med &lt;strong&gt;verdensur&lt;/strong&gt;.&lt;br/&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="60"/>
+        <source>don&apos;t show this again</source>
+        <translation>vis det ikke igen</translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClockConfiguration</name>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="14"/>
+        <source>Clock Settings</source>
+        <translation>Ur-indstillinger</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="20"/>
+        <source>Time</source>
+        <translation>Klokkeslæt</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="26"/>
+        <source>&amp;Show seconds</source>
+        <translation>&amp;Vis sekunder</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="33"/>
+        <source>12 &amp;hour style</source>
+        <translation>12-&amp;timers-stil</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="40"/>
+        <source>&amp;Use UTC</source>
+        <translation>&amp;Brug UTC</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="59"/>
+        <source>Date &amp;format</source>
+        <translation>Dato&amp;format</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="76"/>
+        <source>&amp;Do not show date</source>
+        <translation>&amp;Vis ikke dato</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="86"/>
+        <source>Show date &amp;before time</source>
+        <translation>Vis dato &amp;før klokkeslæt</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="93"/>
+        <source>Show date &amp;after time</source>
+        <translation>Vis dato &amp;efter klokkeslæt</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="100"/>
+        <source>Show date below time on new &amp;line</source>
+        <translation>Vis dato under klokkeslæt på ny &amp;linje</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="107"/>
+        <source>First day of week in calendar</source>
+        <translation>Første dag på ugen i kalender</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="124"/>
+        <source>Orientation</source>
+        <translation>Orientering</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="130"/>
+        <source>Auto&amp;rotate when the panel is vertical</source>
+        <translation>Automatisk &amp;rotering når panelet er lodret</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="50"/>
+        <source>Date</source>
+        <translation>Dato</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Input custom date format</source>
+        <translation>Input brugerdefineret datoformat</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Interpreted sequences of date format are:
+
+d	the day as number without a leading zero (1 to 31)
+dd	the day as number with a leading zero (01 to 31)
+ddd	the abbreviated localized day name (e.g. &apos;Mon&apos; to &apos;Sun&apos;).
+dddd	the long localized day name (e.g. &apos;Monday&apos; to &apos;Sunday&apos;).
+M	the month as number without a leading zero (1-12)
+MM	the month as number with a leading zero (01-12)
+MMM	the abbreviated localized month name (e.g. &apos;Jan&apos; to &apos;Dec&apos;).
+MMMM	the long localized month name (e.g. &apos;January&apos; to &apos;December&apos;).
+yy	the year as two digit number (00-99)
+yyyy	the year as four digit number
+
+All other input characters will be treated as text.
+Any sequence of characters that are enclosed in single quotes (&apos;)
+will also be treated as text and not be used as an expression.
+
+
+Custom date format:</source>
+        <translation>Fortolket sekvenser af datoformat er:
+
+d	dagen som tal uden et foranstillet nul (1 til 31)
+dd	dagen som tal med et foranstillet nul (01 til 31)
+ddd	det forkortet oversatte navn for dagen (f.eks. &apos;Man&apos; til &apos;Søn&apos;).
+dddd	det lange oversatte navn for dagen (f.eks. &apos;Mandag&apos; til &apos;Søndag&apos;).
+M	måneden som tal uden et foranstillet nul (1-12)
+MM	måneden som tal med et foranstillet nul (01-12)
+MMM	det forkortet oversatte navn for måneden (f.eks. Jan&apos; til Dec&apos;).
+MMMM	det lange oversatte navn for måneden (f.eks. Januar&apos; til December&apos;).
+yy	året som tocifret tal (00-99)
+yyyy	året som firecifret tal
+
+Alle andre input-tegn vil blive behandler som tekst.
+Sekvenser af tegn som er omgivet af enkelte anførselstegn (&apos;)
+vil blive behandlet som tekst og ikke blive brugt som et udtryk.
+
+
+Brugerdefineret datoformat:</translation>
+    </message>
+</context>
+</TS>

--- a/lxqt-panel/plugin-clock/clock_de.ts
+++ b/lxqt-panel/plugin-clock/clock_de.ts
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="de">
+<context>
+    <name>FirstDayCombo</name>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="49"/>
+        <source>&lt;locale based&gt;</source>
+        <translation>&lt;Basierend auf lokale Datumseinstellungen&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClock</name>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="57"/>
+        <source>Date&amp;Time (clock) plugin is deprecated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="58"/>
+        <source>The &lt;strong&gt;clock&lt;/strong&gt; plugin is deprecated and will be removed in future version of LXQt. Consider replacing it with &lt;strong&gt;worldclock&lt;/strong&gt;.&lt;br/&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="60"/>
+        <source>don&apos;t show this again</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClockConfiguration</name>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="14"/>
+        <source>Clock Settings</source>
+        <translation>Uhr-Einstellungen</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="20"/>
+        <source>Time</source>
+        <translation>Zeit</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="26"/>
+        <source>&amp;Show seconds</source>
+        <translation>&amp;Sekunden anzeigen</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="33"/>
+        <source>12 &amp;hour style</source>
+        <translation>12 Stunden U&amp;hr-Stil</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="40"/>
+        <source>&amp;Use UTC</source>
+        <translation>&amp;UTC verwenden</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="50"/>
+        <source>Date</source>
+        <translation>Datum</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="59"/>
+        <source>Date &amp;format</source>
+        <translation>Datums&amp;format</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="76"/>
+        <source>&amp;Do not show date</source>
+        <translation>&amp;Datum nicht anzeigen</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="86"/>
+        <source>Show date &amp;before time</source>
+        <translation>Datum &amp;vor Zeit anzeigen</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="93"/>
+        <source>Show date &amp;after time</source>
+        <translation>Datum hinter Uhrzeit &amp;anzeigen</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="100"/>
+        <source>Show date below time on new &amp;line</source>
+        <translation>Datum unterha&amp;lb Uhrzeit anzeigen</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="107"/>
+        <source>First day of week in calendar</source>
+        <translation>Erster Wochentag im Kalender</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="124"/>
+        <source>Orientation</source>
+        <translation>Ausrichtung</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="130"/>
+        <source>Auto&amp;rotate when the panel is vertical</source>
+        <translation>Automatisch d&amp;rehen bei vertikaler Leiste</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Input custom date format</source>
+        <translation>Eigenes Datumsformat</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Interpreted sequences of date format are:
+
+d	the day as number without a leading zero (1 to 31)
+dd	the day as number with a leading zero (01 to 31)
+ddd	the abbreviated localized day name (e.g. &apos;Mon&apos; to &apos;Sun&apos;).
+dddd	the long localized day name (e.g. &apos;Monday&apos; to &apos;Sunday&apos;).
+M	the month as number without a leading zero (1-12)
+MM	the month as number with a leading zero (01-12)
+MMM	the abbreviated localized month name (e.g. &apos;Jan&apos; to &apos;Dec&apos;).
+MMMM	the long localized month name (e.g. &apos;January&apos; to &apos;December&apos;).
+yy	the year as two digit number (00-99)
+yyyy	the year as four digit number
+
+All other input characters will be treated as text.
+Any sequence of characters that are enclosed in single quotes (&apos;)
+will also be treated as text and not be used as an expression.
+
+
+Custom date format:</source>
+        <translation>Interpretierte Datumsformatsequenzen sind:
+
+d	Tag als Zahl ohne führende Null (1 bis 31)
+dd	Tag als Zahl mit führender Null (01 bis 31)
+ddd	abgekürzter lokalisierter Tagesname (d.h. &apos;Mon&apos; bis &apos;Son&apos;).
+dddd	ganzer lokalisierter Tagesname (d.h. &apos;Montag&apos; bis &apos;Sonntag&apos;).
+M	Monat als Zahl ohne führende Null (1-12)
+MM	Monat als Zahl mit führender Null (01-12)
+MMM	abgekürzter lokalisierter Monatsname (d.h. &apos;Jan&apos; bis &apos;Dez&apos;).
+MMMM	ganzer lokalisierter Monatsname (d.h. &apos;Januar&apos; bis &apos;Dezember&apos;).
+yy	Jahr als zweistellige Zahl (00-99)
+yyyy	Jahr als vierstellige Zahl
+
+Alle anderen Zeichen werden als Text behandelt.
+Jede Zeichenfolge, die in einfachen Hochkommas eingeschlossen ist (&apos;),
+wird ebenfalls als Text behandelt und nicht als Ausdruck benutzt.
+
+
+Eigenes Datumsformat:</translation>
+    </message>
+</context>
+</TS>

--- a/lxqt-panel/plugin-clock/clock_el.ts
+++ b/lxqt-panel/plugin-clock/clock_el.ts
@@ -1,0 +1,217 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="el">
+<context>
+    <name>FirstDayCombo</name>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="49"/>
+        <source>&lt;locale based&gt;</source>
+        <translation>&lt;βάσει της τοπικότητας&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClock</name>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="57"/>
+        <source>Date&amp;Time (clock) plugin is deprecated</source>
+        <translation>Το πρόσθετο Ημερομηνία&amp;Ώρα (ρολόι) είναι υπό απόσυρση</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="58"/>
+        <source>The &lt;strong&gt;clock&lt;/strong&gt; plugin is deprecated and will be removed in future version of LXQt. Consider replacing it with &lt;strong&gt;worldclock&lt;/strong&gt;.&lt;br/&gt;</source>
+        <translation>Το πρόσθετο &lt;strong&gt;ρολόι&lt;/strong&gt; είναι υπό απόσυρση και θα αφαιρεθεί σε μια προσεχή έκδοση του LXQt. Φροντίστε να το αντικαταστήσετε με το &lt;strong&gt;παγκόσμιο ρολόι&lt;/strong&gt;.&lt;br/&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="60"/>
+        <source>don&apos;t show this again</source>
+        <translation>Να μην εμφανιστεί ξανά</translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClockConfiguration</name>
+    <message>
+        <source>LXQt Clock Settings</source>
+        <translation type="vanished">Ρυθμίσεις του ρολογιού LXQt</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="14"/>
+        <source>Clock Settings</source>
+        <translation>Ρυθμίσεις του ρολογιού</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="20"/>
+        <source>Time</source>
+        <translation>Ώρα</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="26"/>
+        <source>&amp;Show seconds</source>
+        <translation>Εμ&amp;φάνιση δευτερολέπτων</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="33"/>
+        <source>12 &amp;hour style</source>
+        <translation>12 &amp;ωρη μορφή</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="40"/>
+        <source>&amp;Use UTC</source>
+        <translation>&amp;Χρήση της UTC</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="59"/>
+        <source>Date &amp;format</source>
+        <translation>Μορφή &amp;ημερομηνίας</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="76"/>
+        <source>&amp;Do not show date</source>
+        <translation>&amp;Να μην εμφανίζεται η ημερομηνία</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="86"/>
+        <source>Show date &amp;before time</source>
+        <translation>Εμφάνιση της ημερομηνίας &amp;πριν την ώρα</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="93"/>
+        <source>Show date &amp;after time</source>
+        <translation>Εμφάνιση της ημερομηνίας &amp;μετά την ώρα</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="100"/>
+        <source>Show date below time on new &amp;line</source>
+        <translation>Εμφάνιση της ημερομηνίας κάτω από την ώρα σε νέα &amp;γραμμή</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="107"/>
+        <source>First day of week in calendar</source>
+        <translation>Η πρώτη ημέρα της εβδομάδας στο ημερολόγιο</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="124"/>
+        <source>Orientation</source>
+        <translation>Προσανατολισμός</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="130"/>
+        <source>Auto&amp;rotate when the panel is vertical</source>
+        <translation>Αυτόματη περιστρο&amp;φή όταν ο πίνακας είναι τοποθετημένος κατακόρυφα</translation>
+    </message>
+    <message>
+        <source>&amp;Font</source>
+        <translation type="vanished">&amp;Γραμματοσειρά</translation>
+    </message>
+    <message>
+        <source>Font</source>
+        <translation type="vanished">Γραμματοσειρά</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="50"/>
+        <source>Date</source>
+        <translation>Ημερομηνία</translation>
+    </message>
+    <message>
+        <source>Show &amp;date</source>
+        <translation type="vanished">Εμφάνιση της &amp;ημερομηνίας</translation>
+    </message>
+    <message>
+        <source>D&amp;ate format</source>
+        <translation type="vanished">Μορφή της η&amp;μερομηνίας</translation>
+    </message>
+    <message>
+        <source>Fon&amp;t</source>
+        <translation type="vanished">Γραμματο&amp;σειρά</translation>
+    </message>
+    <message>
+        <source>Show date in &amp;new line</source>
+        <translation type="vanished">Εμφάνιση της ημερομηνίας σε &amp;νέα γραμμή</translation>
+    </message>
+    <message>
+        <source>&amp;Use theme fonts</source>
+        <translation type="vanished">Χρήση των γραμματοσειρών του &amp;θέματος</translation>
+    </message>
+    <message>
+        <source>Time font</source>
+        <translation type="vanished">Γραμματοσειρά της ώρας</translation>
+    </message>
+    <message>
+        <source>Date font</source>
+        <translation type="vanished">Γραμματοσειρά της ημερομηνίας</translation>
+    </message>
+    <message>
+        <source>Ultra light</source>
+        <translation type="vanished">Υπερβολικά φωτεινή</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="vanished">Φωτεινή</translation>
+    </message>
+    <message>
+        <source>Ultra black</source>
+        <translation type="vanished">Υπερβολικά μελανή</translation>
+    </message>
+    <message>
+        <source>Black</source>
+        <translation type="vanished">Μελανή</translation>
+    </message>
+    <message>
+        <source>Bold</source>
+        <translation type="vanished">Έντονη</translation>
+    </message>
+    <message>
+        <source>Demi bold</source>
+        <translation type="vanished">Ελαφρώς έντονη</translation>
+    </message>
+    <message>
+        <source>Italic</source>
+        <translation type="vanished">Πλάγια</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Input custom date format</source>
+        <translation>Εισαγωγή προσαρμοσμένης μορφής ημερομηνίας</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Interpreted sequences of date format are:
+
+d	the day as number without a leading zero (1 to 31)
+dd	the day as number with a leading zero (01 to 31)
+ddd	the abbreviated localized day name (e.g. &apos;Mon&apos; to &apos;Sun&apos;).
+dddd	the long localized day name (e.g. &apos;Monday&apos; to &apos;Sunday&apos;).
+M	the month as number without a leading zero (1-12)
+MM	the month as number with a leading zero (01-12)
+MMM	the abbreviated localized month name (e.g. &apos;Jan&apos; to &apos;Dec&apos;).
+MMMM	the long localized month name (e.g. &apos;January&apos; to &apos;December&apos;).
+yy	the year as two digit number (00-99)
+yyyy	the year as four digit number
+
+All other input characters will be treated as text.
+Any sequence of characters that are enclosed in single quotes (&apos;)
+will also be treated as text and not be used as an expression.
+
+
+Custom date format:</source>
+        <translation>Οι ερμηνευόμενες ακολουθίες της μορφής της ημερομηνίας είναι:
+
+d	η ημέρα ως αριθμός δίχως το αρχικό μηδενικό (1 ως 31)
+dd	η ημέρα ως αριθμός με το αρχικό μηδενικό (01 ως 31)
+ddd	η συντομογραφημένη τοπικοποιημένη ονομασία της ημέρας (π.χ. «Δευ» ως «Κυρ»).
+dddd	η μακριά τοπικοποιημένη ονομασία της ημέρας (π.χ. «Δευτέρα» ως «Κυριακή»).
+M	ο μήνας ως αριθμός δίχως το αρχικό μηδενικό (1-12)
+MM	ο μήνας ως αριθμός με το αρχικό μηδενικό (01-12)
+MMM	η συντομογραφημένη τοπικοποιημένη ονομασία του μήνα (π.χ. «Ιαν» ως «Δεκ»).
+MMMM	η μακριά τοπικοποιημένη ονομασία του μήνα (π.χ. «Ιανουάριος» ως «Δεκέμβριος»).
+yy	το έτος ως διψήφιος αριθμός (00-99)
+yyyy	το έτος ως τετραψήφιος αριθμός
+
+Όλοι οι λοιποί χαρακτήρες εισόδου θα διαχειριστούν ως κείμενο.
+Οποιαδήποτε ακολουθία χαρακτήρων που εγκλείονται σε μονά εισαγωγικά (&apos;)
+θα διαχειρίζονται επίσης ως κείμενο και δεν θα χρησιμοποιούνται ως έκφραση.
+
+
+Προσαρμοσμένη μορφή ημερομηνίας:</translation>
+    </message>
+</context>
+</TS>

--- a/lxqt-panel/plugin-clock/clock_eo.ts
+++ b/lxqt-panel/plugin-clock/clock_eo.ts
@@ -1,0 +1,199 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="eo">
+<context>
+    <name>FirstDayCombo</name>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="49"/>
+        <source>&lt;locale based&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClock</name>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="57"/>
+        <source>Date&amp;Time (clock) plugin is deprecated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="58"/>
+        <source>The &lt;strong&gt;clock&lt;/strong&gt; plugin is deprecated and will be removed in future version of LXQt. Consider replacing it with &lt;strong&gt;worldclock&lt;/strong&gt;.&lt;br/&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="60"/>
+        <source>don&apos;t show this again</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClockConfiguration</name>
+    <message>
+        <source>LXQt Clock Settings</source>
+        <translation type="vanished">Agordoj de horloĝo de LXQt</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="14"/>
+        <source>Clock Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="20"/>
+        <source>Time</source>
+        <translation>Tempo</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="26"/>
+        <source>&amp;Show seconds</source>
+        <translation>Montri &amp;sekundojn</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="33"/>
+        <source>12 &amp;hour style</source>
+        <translation>12-&amp;hora aranĝo</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="40"/>
+        <source>&amp;Use UTC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="59"/>
+        <source>Date &amp;format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="76"/>
+        <source>&amp;Do not show date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="86"/>
+        <source>Show date &amp;before time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="93"/>
+        <source>Show date &amp;after time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="100"/>
+        <source>Show date below time on new &amp;line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="107"/>
+        <source>First day of week in calendar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="124"/>
+        <source>Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="130"/>
+        <source>Auto&amp;rotate when the panel is vertical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Font</source>
+        <translation type="vanished">&amp;Tiparo</translation>
+    </message>
+    <message>
+        <source>Font</source>
+        <translation type="vanished">Tiparo</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="50"/>
+        <source>Date</source>
+        <translation>Dato</translation>
+    </message>
+    <message>
+        <source>Show &amp;date</source>
+        <translation type="vanished">Montri &amp;daton</translation>
+    </message>
+    <message>
+        <source>D&amp;ate format</source>
+        <translation type="vanished">&amp;Aranĝo de dato</translation>
+    </message>
+    <message>
+        <source>Fon&amp;t</source>
+        <translation type="vanished">&amp;Tiparo</translation>
+    </message>
+    <message>
+        <source>Show date in &amp;new line</source>
+        <translation type="vanished">Montri daton en &amp;nova linio</translation>
+    </message>
+    <message>
+        <source>&amp;Use theme fonts</source>
+        <translation type="vanished">&amp;Uzi tiparojn de etoso</translation>
+    </message>
+    <message>
+        <source>Time font</source>
+        <translation type="vanished">Tiparo de tempo</translation>
+    </message>
+    <message>
+        <source>Date font</source>
+        <translation type="vanished">Tiparo de dato</translation>
+    </message>
+    <message>
+        <source>Ultra light</source>
+        <translation type="vanished">Tre maldike</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="vanished">Maldike</translation>
+    </message>
+    <message>
+        <source>Ultra black</source>
+        <translation type="vanished">Tre nigre</translation>
+    </message>
+    <message>
+        <source>Black</source>
+        <translation type="vanished">Nigre</translation>
+    </message>
+    <message>
+        <source>Bold</source>
+        <translation type="vanished">Dike</translation>
+    </message>
+    <message>
+        <source>Demi bold</source>
+        <translation type="vanished">Mezdike</translation>
+    </message>
+    <message>
+        <source>Italic</source>
+        <translation type="vanished">Kursive</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Input custom date format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Interpreted sequences of date format are:
+
+d	the day as number without a leading zero (1 to 31)
+dd	the day as number with a leading zero (01 to 31)
+ddd	the abbreviated localized day name (e.g. &apos;Mon&apos; to &apos;Sun&apos;).
+dddd	the long localized day name (e.g. &apos;Monday&apos; to &apos;Sunday&apos;).
+M	the month as number without a leading zero (1-12)
+MM	the month as number with a leading zero (01-12)
+MMM	the abbreviated localized month name (e.g. &apos;Jan&apos; to &apos;Dec&apos;).
+MMMM	the long localized month name (e.g. &apos;January&apos; to &apos;December&apos;).
+yy	the year as two digit number (00-99)
+yyyy	the year as four digit number
+
+All other input characters will be treated as text.
+Any sequence of characters that are enclosed in single quotes (&apos;)
+will also be treated as text and not be used as an expression.
+
+
+Custom date format:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/lxqt-panel/plugin-clock/clock_es.ts
+++ b/lxqt-panel/plugin-clock/clock_es.ts
@@ -1,0 +1,217 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="es">
+<context>
+    <name>FirstDayCombo</name>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="49"/>
+        <source>&lt;locale based&gt;</source>
+        <translation>&lt;dependiente de la configuración regional&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClock</name>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="57"/>
+        <source>Date&amp;Time (clock) plugin is deprecated</source>
+        <translation>El complemento Fecha y hora (reloj) está obsoleto</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="58"/>
+        <source>The &lt;strong&gt;clock&lt;/strong&gt; plugin is deprecated and will be removed in future version of LXQt. Consider replacing it with &lt;strong&gt;worldclock&lt;/strong&gt;.&lt;br/&gt;</source>
+        <translation>El complemento &lt;strong&gt;reloj&lt;/strong&gt; está obsoleto y será eliminado en una versión futura de LXQt. Considere sustituirlo por &lt;strong&gt;Reloj mundial&lt;/strong&gt;.&lt;br/&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="60"/>
+        <source>don&apos;t show this again</source>
+        <translation>no mostrar de nuevo</translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClockConfiguration</name>
+    <message>
+        <source>LXQt Clock Settings</source>
+        <translation type="vanished">Configuración del reloj de LXQt</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="14"/>
+        <source>Clock Settings</source>
+        <translation>Configuración del reloj</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="20"/>
+        <source>Time</source>
+        <translation>Hora</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="26"/>
+        <source>&amp;Show seconds</source>
+        <translation>&amp;Mostrar los segundos</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="33"/>
+        <source>12 &amp;hour style</source>
+        <translation>Estilo de 12 &amp;horas</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="40"/>
+        <source>&amp;Use UTC</source>
+        <translation>&amp;Usar UTC</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="59"/>
+        <source>Date &amp;format</source>
+        <translation>&amp;Formato de fecha</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="76"/>
+        <source>&amp;Do not show date</source>
+        <translation>No mostrar la fecha</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="86"/>
+        <source>Show date &amp;before time</source>
+        <translation>Mostrar la fecha antes que la hora</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="93"/>
+        <source>Show date &amp;after time</source>
+        <translation>Mostrar la fecha después de la hora</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="100"/>
+        <source>Show date below time on new &amp;line</source>
+        <translation>Mostrar la fecha bajo la hora en una &amp;línea nueva</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="107"/>
+        <source>First day of week in calendar</source>
+        <translation>Primer día de la semana en el calendario</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="124"/>
+        <source>Orientation</source>
+        <translation>Orientación</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="130"/>
+        <source>Auto&amp;rotate when the panel is vertical</source>
+        <translation>&amp;Rotar automáticamente cuando el panel esté vertical</translation>
+    </message>
+    <message>
+        <source>&amp;Font</source>
+        <translation type="vanished">&amp;Fuente</translation>
+    </message>
+    <message>
+        <source>Font</source>
+        <translation type="vanished">Fuente</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="50"/>
+        <source>Date</source>
+        <translation>Fecha</translation>
+    </message>
+    <message>
+        <source>Show &amp;date</source>
+        <translation type="vanished">Mostrar &amp;fecha</translation>
+    </message>
+    <message>
+        <source>D&amp;ate format</source>
+        <translation type="vanished">Formato de &amp;fecha</translation>
+    </message>
+    <message>
+        <source>Fon&amp;t</source>
+        <translation type="vanished">Fuen&amp;te</translation>
+    </message>
+    <message>
+        <source>Show date in &amp;new line</source>
+        <translation type="vanished">Mostrar fecha en &amp;nueva línea</translation>
+    </message>
+    <message>
+        <source>&amp;Use theme fonts</source>
+        <translation type="vanished">&amp;Usar fuente del tema</translation>
+    </message>
+    <message>
+        <source>Time font</source>
+        <translation type="vanished">Fuente de la hora</translation>
+    </message>
+    <message>
+        <source>Date font</source>
+        <translation type="vanished">Fuente de la fecha</translation>
+    </message>
+    <message>
+        <source>Ultra light</source>
+        <translation type="vanished">Ultra ligero</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="vanished">Ligero</translation>
+    </message>
+    <message>
+        <source>Ultra black</source>
+        <translation type="vanished">Ultra negro</translation>
+    </message>
+    <message>
+        <source>Black</source>
+        <translation type="vanished">Negro</translation>
+    </message>
+    <message>
+        <source>Bold</source>
+        <translation type="vanished">Negrita</translation>
+    </message>
+    <message>
+        <source>Demi bold</source>
+        <translation type="vanished">Semi negrita</translation>
+    </message>
+    <message>
+        <source>Italic</source>
+        <translation type="vanished">Cursiva</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Input custom date format</source>
+        <translation>Introducir un formato de fecha personalizado</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Interpreted sequences of date format are:
+
+d	the day as number without a leading zero (1 to 31)
+dd	the day as number with a leading zero (01 to 31)
+ddd	the abbreviated localized day name (e.g. &apos;Mon&apos; to &apos;Sun&apos;).
+dddd	the long localized day name (e.g. &apos;Monday&apos; to &apos;Sunday&apos;).
+M	the month as number without a leading zero (1-12)
+MM	the month as number with a leading zero (01-12)
+MMM	the abbreviated localized month name (e.g. &apos;Jan&apos; to &apos;Dec&apos;).
+MMMM	the long localized month name (e.g. &apos;January&apos; to &apos;December&apos;).
+yy	the year as two digit number (00-99)
+yyyy	the year as four digit number
+
+All other input characters will be treated as text.
+Any sequence of characters that are enclosed in single quotes (&apos;)
+will also be treated as text and not be used as an expression.
+
+
+Custom date format:</source>
+        <translation>Las secuencias de formato de fecha interpretadas son:
+
+d	el día como número sin cero de relleno (1 a 31)
+dd	el día como número con cero de relleno (01 a 31)
+ddd	el nombre del día abreviado en la configuración regional (p. ej. &apos;Lun&apos; a &apos;Dom&apos;).
+dddd	el nombre del día en la configuración regional (p. ej. &apos;Lunes&apos; a &apos;Domingo&apos;).
+M	el mes como número sin cero de relleno (1-12)
+MM	el mes como número sin cero de relleno (01-12)
+MMM	el nombre del mes abreviado en la configuración regional (p. ej. &apos;Ene&apos; a &apos;Dic&apos;).
+MMMM	el nombre del mes en la configuración regional (p. ej. &apos;Enero&apos; a &apos;Diciembre&apos;).
+yy	el año como número de dos dígitos (00-99)
+yyyy	el año como número de cuatro dígitos
+
+Todo lo demás se interpretará como texto.
+Cualquier secuencia de caracteres entre comillas simples (&apos;)
+también será tratada como texto y no se usará como una expresión.
+
+
+Formato de fecha personalizado:</translation>
+    </message>
+</context>
+</TS>

--- a/lxqt-panel/plugin-clock/clock_es_UY.ts
+++ b/lxqt-panel/plugin-clock/clock_es_UY.ts
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="es_UY">
+<context>
+    <name>FirstDayCombo</name>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="49"/>
+        <source>&lt;locale based&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClock</name>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="57"/>
+        <source>Date&amp;Time (clock) plugin is deprecated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="58"/>
+        <source>The &lt;strong&gt;clock&lt;/strong&gt; plugin is deprecated and will be removed in future version of LXQt. Consider replacing it with &lt;strong&gt;worldclock&lt;/strong&gt;.&lt;br/&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="60"/>
+        <source>don&apos;t show this again</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClockConfiguration</name>
+    <message>
+        <source>LXQt Clock Settings</source>
+        <translation type="vanished">Configuración de Reloj LXQt</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="14"/>
+        <source>Clock Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="20"/>
+        <source>Time</source>
+        <translation>Hora</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="26"/>
+        <source>&amp;Show seconds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="33"/>
+        <source>12 &amp;hour style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="40"/>
+        <source>&amp;Use UTC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="59"/>
+        <source>Date &amp;format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="76"/>
+        <source>&amp;Do not show date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="86"/>
+        <source>Show date &amp;before time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="93"/>
+        <source>Show date &amp;after time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="100"/>
+        <source>Show date below time on new &amp;line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="107"/>
+        <source>First day of week in calendar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="124"/>
+        <source>Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="130"/>
+        <source>Auto&amp;rotate when the panel is vertical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="50"/>
+        <source>Date</source>
+        <translation>Fecha</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Input custom date format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Interpreted sequences of date format are:
+
+d	the day as number without a leading zero (1 to 31)
+dd	the day as number with a leading zero (01 to 31)
+ddd	the abbreviated localized day name (e.g. &apos;Mon&apos; to &apos;Sun&apos;).
+dddd	the long localized day name (e.g. &apos;Monday&apos; to &apos;Sunday&apos;).
+M	the month as number without a leading zero (1-12)
+MM	the month as number with a leading zero (01-12)
+MMM	the abbreviated localized month name (e.g. &apos;Jan&apos; to &apos;Dec&apos;).
+MMMM	the long localized month name (e.g. &apos;January&apos; to &apos;December&apos;).
+yy	the year as two digit number (00-99)
+yyyy	the year as four digit number
+
+All other input characters will be treated as text.
+Any sequence of characters that are enclosed in single quotes (&apos;)
+will also be treated as text and not be used as an expression.
+
+
+Custom date format:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/lxqt-panel/plugin-clock/clock_es_VE.ts
+++ b/lxqt-panel/plugin-clock/clock_es_VE.ts
@@ -1,0 +1,199 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="es_VE">
+<context>
+    <name>FirstDayCombo</name>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="49"/>
+        <source>&lt;locale based&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClock</name>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="57"/>
+        <source>Date&amp;Time (clock) plugin is deprecated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="58"/>
+        <source>The &lt;strong&gt;clock&lt;/strong&gt; plugin is deprecated and will be removed in future version of LXQt. Consider replacing it with &lt;strong&gt;worldclock&lt;/strong&gt;.&lt;br/&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="60"/>
+        <source>don&apos;t show this again</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClockConfiguration</name>
+    <message>
+        <source>LXQt Clock Settings</source>
+        <translation type="vanished">Configuración de Reloj LXQt</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="14"/>
+        <source>Clock Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="20"/>
+        <source>Time</source>
+        <translation>Hora</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="26"/>
+        <source>&amp;Show seconds</source>
+        <translation>Mostrar &amp;Segundos</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="33"/>
+        <source>12 &amp;hour style</source>
+        <translation>Estilo 12 &amp;horas</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="40"/>
+        <source>&amp;Use UTC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="59"/>
+        <source>Date &amp;format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="76"/>
+        <source>&amp;Do not show date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="86"/>
+        <source>Show date &amp;before time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="93"/>
+        <source>Show date &amp;after time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="100"/>
+        <source>Show date below time on new &amp;line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="107"/>
+        <source>First day of week in calendar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="124"/>
+        <source>Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="130"/>
+        <source>Auto&amp;rotate when the panel is vertical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Font</source>
+        <translation type="vanished">&amp;Fuente</translation>
+    </message>
+    <message>
+        <source>Font</source>
+        <translation type="vanished">Fuente</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="50"/>
+        <source>Date</source>
+        <translation>Fecha</translation>
+    </message>
+    <message>
+        <source>Show &amp;date</source>
+        <translation type="vanished">Mostrar &amp;fecha</translation>
+    </message>
+    <message>
+        <source>D&amp;ate format</source>
+        <translation type="vanished">Formato &amp;De Fecha</translation>
+    </message>
+    <message>
+        <source>Fon&amp;t</source>
+        <translation type="vanished">Fuen&amp;te</translation>
+    </message>
+    <message>
+        <source>Show date in &amp;new line</source>
+        <translation type="vanished">Mostrar la fecha en una &amp;nueva linea</translation>
+    </message>
+    <message>
+        <source>&amp;Use theme fonts</source>
+        <translation type="vanished">&amp;Usar las letras del tema</translation>
+    </message>
+    <message>
+        <source>Time font</source>
+        <translation type="vanished">Fuente de hora</translation>
+    </message>
+    <message>
+        <source>Date font</source>
+        <translation type="vanished">Fuente de fecha</translation>
+    </message>
+    <message>
+        <source>Ultra light</source>
+        <translation type="vanished">Ultra delgada</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="vanished">Delgada</translation>
+    </message>
+    <message>
+        <source>Ultra black</source>
+        <translation type="vanished">Ultra negrita</translation>
+    </message>
+    <message>
+        <source>Black</source>
+        <translation type="vanished">Negra</translation>
+    </message>
+    <message>
+        <source>Bold</source>
+        <translation type="vanished">Negrita</translation>
+    </message>
+    <message>
+        <source>Demi bold</source>
+        <translation type="vanished">Semi negrilla</translation>
+    </message>
+    <message>
+        <source>Italic</source>
+        <translation type="vanished">Italica</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Input custom date format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Interpreted sequences of date format are:
+
+d	the day as number without a leading zero (1 to 31)
+dd	the day as number with a leading zero (01 to 31)
+ddd	the abbreviated localized day name (e.g. &apos;Mon&apos; to &apos;Sun&apos;).
+dddd	the long localized day name (e.g. &apos;Monday&apos; to &apos;Sunday&apos;).
+M	the month as number without a leading zero (1-12)
+MM	the month as number with a leading zero (01-12)
+MMM	the abbreviated localized month name (e.g. &apos;Jan&apos; to &apos;Dec&apos;).
+MMMM	the long localized month name (e.g. &apos;January&apos; to &apos;December&apos;).
+yy	the year as two digit number (00-99)
+yyyy	the year as four digit number
+
+All other input characters will be treated as text.
+Any sequence of characters that are enclosed in single quotes (&apos;)
+will also be treated as text and not be used as an expression.
+
+
+Custom date format:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/lxqt-panel/plugin-clock/clock_eu.ts
+++ b/lxqt-panel/plugin-clock/clock_eu.ts
@@ -1,0 +1,199 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="eu">
+<context>
+    <name>FirstDayCombo</name>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="49"/>
+        <source>&lt;locale based&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClock</name>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="57"/>
+        <source>Date&amp;Time (clock) plugin is deprecated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="58"/>
+        <source>The &lt;strong&gt;clock&lt;/strong&gt; plugin is deprecated and will be removed in future version of LXQt. Consider replacing it with &lt;strong&gt;worldclock&lt;/strong&gt;.&lt;br/&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="60"/>
+        <source>don&apos;t show this again</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClockConfiguration</name>
+    <message>
+        <source>LXQt Clock Settings</source>
+        <translation type="vanished">LXQt erlojuaren ezarpenak</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="14"/>
+        <source>Clock Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="20"/>
+        <source>Time</source>
+        <translation>Ordua</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="26"/>
+        <source>&amp;Show seconds</source>
+        <translation>&amp;Erakutsi segundoak</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="33"/>
+        <source>12 &amp;hour style</source>
+        <translation>12 &amp;orduko estiloa</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="40"/>
+        <source>&amp;Use UTC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="59"/>
+        <source>Date &amp;format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="76"/>
+        <source>&amp;Do not show date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="86"/>
+        <source>Show date &amp;before time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="93"/>
+        <source>Show date &amp;after time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="100"/>
+        <source>Show date below time on new &amp;line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="107"/>
+        <source>First day of week in calendar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="124"/>
+        <source>Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="130"/>
+        <source>Auto&amp;rotate when the panel is vertical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Font</source>
+        <translation type="vanished">&amp;Letra-tipoa</translation>
+    </message>
+    <message>
+        <source>Font</source>
+        <translation type="vanished">Letra-tipoa</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="50"/>
+        <source>Date</source>
+        <translation>Data</translation>
+    </message>
+    <message>
+        <source>Show &amp;date</source>
+        <translation type="vanished">Erakutsi &amp;data</translation>
+    </message>
+    <message>
+        <source>D&amp;ate format</source>
+        <translation type="vanished">D&amp;ata-formatua</translation>
+    </message>
+    <message>
+        <source>Fon&amp;t</source>
+        <translation type="vanished">Letra-&amp;tipoa</translation>
+    </message>
+    <message>
+        <source>Show date in &amp;new line</source>
+        <translation type="vanished">Erakutsi data lerro &amp;berri batean</translation>
+    </message>
+    <message>
+        <source>&amp;Use theme fonts</source>
+        <translation type="vanished">&amp;Erabili letra-tipoen gaiak</translation>
+    </message>
+    <message>
+        <source>Time font</source>
+        <translation type="vanished">Orduaren letra-tipoa</translation>
+    </message>
+    <message>
+        <source>Date font</source>
+        <translation type="vanished">Dataren letra-tipoa</translation>
+    </message>
+    <message>
+        <source>Ultra light</source>
+        <translation type="vanished">Ultra argia</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="vanished">Argia</translation>
+    </message>
+    <message>
+        <source>Ultra black</source>
+        <translation type="vanished">Ultra beltza</translation>
+    </message>
+    <message>
+        <source>Black</source>
+        <translation type="vanished">Beltza</translation>
+    </message>
+    <message>
+        <source>Bold</source>
+        <translation type="vanished">Lodia</translation>
+    </message>
+    <message>
+        <source>Demi bold</source>
+        <translation type="vanished">Erdi-lodia</translation>
+    </message>
+    <message>
+        <source>Italic</source>
+        <translation type="vanished">Etzana</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Input custom date format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Interpreted sequences of date format are:
+
+d	the day as number without a leading zero (1 to 31)
+dd	the day as number with a leading zero (01 to 31)
+ddd	the abbreviated localized day name (e.g. &apos;Mon&apos; to &apos;Sun&apos;).
+dddd	the long localized day name (e.g. &apos;Monday&apos; to &apos;Sunday&apos;).
+M	the month as number without a leading zero (1-12)
+MM	the month as number with a leading zero (01-12)
+MMM	the abbreviated localized month name (e.g. &apos;Jan&apos; to &apos;Dec&apos;).
+MMMM	the long localized month name (e.g. &apos;January&apos; to &apos;December&apos;).
+yy	the year as two digit number (00-99)
+yyyy	the year as four digit number
+
+All other input characters will be treated as text.
+Any sequence of characters that are enclosed in single quotes (&apos;)
+will also be treated as text and not be used as an expression.
+
+
+Custom date format:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/lxqt-panel/plugin-clock/clock_fi.ts
+++ b/lxqt-panel/plugin-clock/clock_fi.ts
@@ -1,0 +1,199 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fi">
+<context>
+    <name>FirstDayCombo</name>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="49"/>
+        <source>&lt;locale based&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClock</name>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="57"/>
+        <source>Date&amp;Time (clock) plugin is deprecated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="58"/>
+        <source>The &lt;strong&gt;clock&lt;/strong&gt; plugin is deprecated and will be removed in future version of LXQt. Consider replacing it with &lt;strong&gt;worldclock&lt;/strong&gt;.&lt;br/&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="60"/>
+        <source>don&apos;t show this again</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClockConfiguration</name>
+    <message>
+        <source>LXQt Clock Settings</source>
+        <translation type="vanished">LXQtin kellon asetukset</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="14"/>
+        <source>Clock Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="20"/>
+        <source>Time</source>
+        <translation>Aika</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="26"/>
+        <source>&amp;Show seconds</source>
+        <translation>&amp;Näytä sekunnit</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="33"/>
+        <source>12 &amp;hour style</source>
+        <translation>&amp;12 tunnin esitystapa</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="40"/>
+        <source>&amp;Use UTC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="59"/>
+        <source>Date &amp;format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="76"/>
+        <source>&amp;Do not show date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="86"/>
+        <source>Show date &amp;before time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="93"/>
+        <source>Show date &amp;after time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="100"/>
+        <source>Show date below time on new &amp;line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="107"/>
+        <source>First day of week in calendar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="124"/>
+        <source>Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="130"/>
+        <source>Auto&amp;rotate when the panel is vertical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Font</source>
+        <translation type="vanished">&amp;Kirjasin</translation>
+    </message>
+    <message>
+        <source>Font</source>
+        <translation type="vanished">Kirjasin</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="50"/>
+        <source>Date</source>
+        <translation>Päivä</translation>
+    </message>
+    <message>
+        <source>Show &amp;date</source>
+        <translation type="vanished">Näytä &amp;päivä</translation>
+    </message>
+    <message>
+        <source>D&amp;ate format</source>
+        <translation type="vanished">Päiväyksen &amp;muoto</translation>
+    </message>
+    <message>
+        <source>Fon&amp;t</source>
+        <translation type="vanished">Ki&amp;rjasin</translation>
+    </message>
+    <message>
+        <source>Show date in &amp;new line</source>
+        <translation type="vanished">Näytä päivä &amp;omalla rivillä</translation>
+    </message>
+    <message>
+        <source>&amp;Use theme fonts</source>
+        <translation type="vanished">Käytä &amp;teeman kirjasimia</translation>
+    </message>
+    <message>
+        <source>Time font</source>
+        <translation type="vanished">Kirjasin aikaa varten</translation>
+    </message>
+    <message>
+        <source>Date font</source>
+        <translation type="vanished">Kirjasin päiväystä varten</translation>
+    </message>
+    <message>
+        <source>Ultra light</source>
+        <translation type="vanished">Todella vaalea</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="vanished">Vaalea</translation>
+    </message>
+    <message>
+        <source>Ultra black</source>
+        <translation type="vanished">Todella musta</translation>
+    </message>
+    <message>
+        <source>Black</source>
+        <translation type="vanished">Musta</translation>
+    </message>
+    <message>
+        <source>Bold</source>
+        <translation type="vanished">Lihavoitu</translation>
+    </message>
+    <message>
+        <source>Demi bold</source>
+        <translation type="vanished">Hieman lihavoitu</translation>
+    </message>
+    <message>
+        <source>Italic</source>
+        <translation type="vanished">Kursivoitu</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Input custom date format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Interpreted sequences of date format are:
+
+d	the day as number without a leading zero (1 to 31)
+dd	the day as number with a leading zero (01 to 31)
+ddd	the abbreviated localized day name (e.g. &apos;Mon&apos; to &apos;Sun&apos;).
+dddd	the long localized day name (e.g. &apos;Monday&apos; to &apos;Sunday&apos;).
+M	the month as number without a leading zero (1-12)
+MM	the month as number with a leading zero (01-12)
+MMM	the abbreviated localized month name (e.g. &apos;Jan&apos; to &apos;Dec&apos;).
+MMMM	the long localized month name (e.g. &apos;January&apos; to &apos;December&apos;).
+yy	the year as two digit number (00-99)
+yyyy	the year as four digit number
+
+All other input characters will be treated as text.
+Any sequence of characters that are enclosed in single quotes (&apos;)
+will also be treated as text and not be used as an expression.
+
+
+Custom date format:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/lxqt-panel/plugin-clock/clock_fr.ts
+++ b/lxqt-panel/plugin-clock/clock_fr.ts
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fr">
+<context>
+    <name>FirstDayCombo</name>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="49"/>
+        <source>&lt;locale based&gt;</source>
+        <translation>&lt;basée sur locale&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClock</name>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="57"/>
+        <source>Date&amp;Time (clock) plugin is deprecated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="58"/>
+        <source>The &lt;strong&gt;clock&lt;/strong&gt; plugin is deprecated and will be removed in future version of LXQt. Consider replacing it with &lt;strong&gt;worldclock&lt;/strong&gt;.&lt;br/&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="60"/>
+        <source>don&apos;t show this again</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClockConfiguration</name>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="14"/>
+        <source>Clock Settings</source>
+        <translation>Paramétrage de l&apos;horloge</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="20"/>
+        <source>Time</source>
+        <translation>Heure</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="26"/>
+        <source>&amp;Show seconds</source>
+        <translation>&amp;Montrer les secondes</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="33"/>
+        <source>12 &amp;hour style</source>
+        <translation>Style 12 &amp;heures</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="40"/>
+        <source>&amp;Use UTC</source>
+        <translation>&amp;Utiliser UTC</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="59"/>
+        <source>Date &amp;format</source>
+        <translation>&amp;Format de la date</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="76"/>
+        <source>&amp;Do not show date</source>
+        <translation>&amp;Ne pas afficher la date</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="86"/>
+        <source>Show date &amp;before time</source>
+        <translation>Afficher la date a&amp;vant l&apos;heure</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="93"/>
+        <source>Show date &amp;after time</source>
+        <translation>Afficher la date a&amp;près l&apos;heure</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="100"/>
+        <source>Show date below time on new &amp;line</source>
+        <translation>Afficher la date &amp;sous l&apos;heure, sur une nouvelle ligne</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="107"/>
+        <source>First day of week in calendar</source>
+        <translation>Premier jour de la semaine</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="124"/>
+        <source>Orientation</source>
+        <translation>Orientation</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="130"/>
+        <source>Auto&amp;rotate when the panel is vertical</source>
+        <translation>&amp;Rotation automatique quand le tableau est vertical</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="50"/>
+        <source>Date</source>
+        <translation>Date</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Input custom date format</source>
+        <translation>Saisie d&apos;un format de date personnalisé</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Interpreted sequences of date format are:
+
+d	the day as number without a leading zero (1 to 31)
+dd	the day as number with a leading zero (01 to 31)
+ddd	the abbreviated localized day name (e.g. &apos;Mon&apos; to &apos;Sun&apos;).
+dddd	the long localized day name (e.g. &apos;Monday&apos; to &apos;Sunday&apos;).
+M	the month as number without a leading zero (1-12)
+MM	the month as number with a leading zero (01-12)
+MMM	the abbreviated localized month name (e.g. &apos;Jan&apos; to &apos;Dec&apos;).
+MMMM	the long localized month name (e.g. &apos;January&apos; to &apos;December&apos;).
+yy	the year as two digit number (00-99)
+yyyy	the year as four digit number
+
+All other input characters will be treated as text.
+Any sequence of characters that are enclosed in single quotes (&apos;)
+will also be treated as text and not be used as an expression.
+
+
+Custom date format:</source>
+        <translation>Interprétation des séquences pour le format de la date :
+
+d	le jour du mois, un nombre sans zéro de début (1 to 31)
+dd	le jour du mois, un nombre avec un zéro de débu éventuel (01 to 31)
+ddd	le jour de la semaine, en abréviation locale (ex. &apos;Lun&apos; à &apos;Dim&apos;).
+dddd	le jour de la semaine, non abrégé (ex. &apos;Lundi&apos; à &apos;Dimanche&apos;).
+M	le mois, un nombre sans zéro de débu (1-12)
+MM	le mois, un nombre avec un zéro de débu éventuel (01-12)
+MMM	le mois, en abréviation locale (ex. &apos;Jan&apos; à &apos;Déc&apos;).
+MMMM	le mois, non abrégée (ex. &apos;Janvier&apos; à &apos;Décembre&apos;).
+yy	l&apos;année, nombre à deux digits (00-99)
+yyyy	l&apos;année, nombre à quatre digits
+
+Toute autre saisie sera considérée comme étant du texte.
+Toute séquence de caractères inclue dans des guillemets simples (&apos;)
+sera également considérée comme étant du texte et non comme une expression.
+
+
+Format de date personnalisé :</translation>
+    </message>
+</context>
+</TS>

--- a/lxqt-panel/plugin-clock/clock_hr.ts
+++ b/lxqt-panel/plugin-clock/clock_hr.ts
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="hr">
+<context>
+    <name>FirstDayCombo</name>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="49"/>
+        <source>&lt;locale based&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClock</name>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="57"/>
+        <source>Date&amp;Time (clock) plugin is deprecated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="58"/>
+        <source>The &lt;strong&gt;clock&lt;/strong&gt; plugin is deprecated and will be removed in future version of LXQt. Consider replacing it with &lt;strong&gt;worldclock&lt;/strong&gt;.&lt;br/&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="60"/>
+        <source>don&apos;t show this again</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClockConfiguration</name>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="14"/>
+        <source>Clock Settings</source>
+        <translation type="unfinished">Postavke sata</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="20"/>
+        <source>Time</source>
+        <translation type="unfinished">Vrijeme</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="26"/>
+        <source>&amp;Show seconds</source>
+        <translation type="unfinished">&amp;Pokaži sekunde</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="33"/>
+        <source>12 &amp;hour style</source>
+        <translation type="unfinished">12 &amp;satni stil</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="40"/>
+        <source>&amp;Use UTC</source>
+        <translation type="unfinished">&amp;Koristi UTC</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="76"/>
+        <source>&amp;Do not show date</source>
+        <translation type="unfinished">&amp;Ne pokazuj datum</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="86"/>
+        <source>Show date &amp;before time</source>
+        <translation type="unfinished">Pokaži datum &amp;prije vremena</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="93"/>
+        <source>Show date &amp;after time</source>
+        <translation type="unfinished">Pokaži datum &amp;poslije vremena</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="100"/>
+        <source>Show date below time on new &amp;line</source>
+        <translation type="unfinished">Pokaži datum ispod u novom &amp;retku</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="107"/>
+        <source>First day of week in calendar</source>
+        <translation type="unfinished">Prvi dan u tjednu u kalendaru</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="124"/>
+        <source>Orientation</source>
+        <translation type="unfinished">Orijentacija</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="130"/>
+        <source>Auto&amp;rotate when the panel is vertical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="50"/>
+        <source>Date</source>
+        <translation type="unfinished">Datum</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="59"/>
+        <source>Date &amp;format</source>
+        <translation type="unfinished">Format &amp;datuma</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Input custom date format</source>
+        <translation type="unfinished">Unesite prilagođeni format datuma</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Interpreted sequences of date format are:
+
+d	the day as number without a leading zero (1 to 31)
+dd	the day as number with a leading zero (01 to 31)
+ddd	the abbreviated localized day name (e.g. &apos;Mon&apos; to &apos;Sun&apos;).
+dddd	the long localized day name (e.g. &apos;Monday&apos; to &apos;Sunday&apos;).
+M	the month as number without a leading zero (1-12)
+MM	the month as number with a leading zero (01-12)
+MMM	the abbreviated localized month name (e.g. &apos;Jan&apos; to &apos;Dec&apos;).
+MMMM	the long localized month name (e.g. &apos;January&apos; to &apos;December&apos;).
+yy	the year as two digit number (00-99)
+yyyy	the year as four digit number
+
+All other input characters will be treated as text.
+Any sequence of characters that are enclosed in single quotes (&apos;)
+will also be treated as text and not be used as an expression.
+
+
+Custom date format:</source>
+        <translation type="unfinished">Interpretirani dijelovi formata datuma su:
+
+d	dan kao broj bez početne nule (1 to 31)
+dd	dan kao broj sa početnom nulom (01 to 31)
+ddd	skraćeno lokalizirano ime dana (npr. &apos;Pon&apos; do &apos;Ned&apos;).
+dddd	dugo lokalizirano ime  (npr. &apos;Ponedjeljak&apos; do &apos;Nedjelje&apos;).
+M	mjesec kao broj bezpočetne nule (1-12)
+MM	mjesec kao broj sa početnom nulom (01-12)
+MMM	skraćeno lokalizirano ime mjeseca (npr. &apos;Sij&apos; do &apos;Pro&apos;).
+MMMM	dugo lokalizirano ime mjeseca (npr. &apos;Siječanj&apos; do &apos;Prosinac&apos;).
+yy	godina sa dvoznamenkastim brojemr (00-99)
+yyyy	godina kao četveroznamenkasti broj
+
+Svi ostali znakovi unosa biti će tretirani kao tekst.
+Bilo koji dio znakova  koji su zatvoreni jednostrukim navodnicima (&apos;)
+će također biti interpretirani kao tekst.i neće biti korišteni kao izraz
+
+
+Prilagođeni format datuma:</translation>
+    </message>
+</context>
+</TS>

--- a/lxqt-panel/plugin-clock/clock_hu.ts
+++ b/lxqt-panel/plugin-clock/clock_hu.ts
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="hu">
+<context>
+    <name>FirstDayCombo</name>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="49"/>
+        <source>&lt;locale based&gt;</source>
+        <translation></translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClock</name>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="57"/>
+        <source>Date&amp;Time (clock) plugin is deprecated</source>
+        <translation>A Date&amp;Time (clock) plugin elavult</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="58"/>
+        <source>The &lt;strong&gt;clock&lt;/strong&gt; plugin is deprecated and will be removed in future version of LXQt. Consider replacing it with &lt;strong&gt;worldclock&lt;/strong&gt;.&lt;br/&gt;</source>
+        <translation>A &lt;strong&gt;clock&lt;/strong&gt; plugin idejétmúlt és az LXQt újabb kiadásaiban már nem lesz. Helyette a &lt;strong&gt;worldclock&lt;/strong&gt;plugin lesz.&lt;br/</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="60"/>
+        <source>don&apos;t show this again</source>
+        <translation>Ne lássuk ezt többé</translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClockConfiguration</name>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="14"/>
+        <source>Clock Settings</source>
+        <translation>Órabeállítás</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="20"/>
+        <source>Time</source>
+        <translation>Idő</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="26"/>
+        <source>&amp;Show seconds</source>
+        <translation>Má&amp;sodpercek</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="33"/>
+        <source>12 &amp;hour style</source>
+        <translation>12 órás &amp;stílus</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="40"/>
+        <source>&amp;Use UTC</source>
+        <translation>&amp;UTC használat</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="76"/>
+        <source>&amp;Do not show date</source>
+        <translation>Ne legyen &amp;dátum</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="86"/>
+        <source>Show date &amp;before time</source>
+        <translation>&amp;Dátum az óra előtt</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="93"/>
+        <source>Show date &amp;after time</source>
+        <translation>Dátum &amp;az óra után</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="100"/>
+        <source>Show date below time on new &amp;line</source>
+        <translation>Dátum az óráva&amp;l új sorban</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="107"/>
+        <source>First day of week in calendar</source>
+        <translation>A hét első napja</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="124"/>
+        <source>Orientation</source>
+        <translation>Helyzet</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="130"/>
+        <source>Auto&amp;rotate when the panel is vertical</source>
+        <translation>Függélyes panelnál automata gö&amp;rgetés</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="50"/>
+        <source>Date</source>
+        <translation>Dátum</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="59"/>
+        <source>Date &amp;format</source>
+        <translation>Dá&amp;tumalak</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Input custom date format</source>
+        <translation>Egyéni dátumalak</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Interpreted sequences of date format are:
+
+d	the day as number without a leading zero (1 to 31)
+dd	the day as number with a leading zero (01 to 31)
+ddd	the abbreviated localized day name (e.g. &apos;Mon&apos; to &apos;Sun&apos;).
+dddd	the long localized day name (e.g. &apos;Monday&apos; to &apos;Sunday&apos;).
+M	the month as number without a leading zero (1-12)
+MM	the month as number with a leading zero (01-12)
+MMM	the abbreviated localized month name (e.g. &apos;Jan&apos; to &apos;Dec&apos;).
+MMMM	the long localized month name (e.g. &apos;January&apos; to &apos;December&apos;).
+yy	the year as two digit number (00-99)
+yyyy	the year as four digit number
+
+All other input characters will be treated as text.
+Any sequence of characters that are enclosed in single quotes (&apos;)
+will also be treated as text and not be used as an expression.
+
+
+Custom date format:</source>
+        <translation>Értelmezett dátumformázások:
+
+d	a nap számként bevezető nulla nélkül (1 - 31)
+dd	a nap számként bevezető nullával (01 - 31)
+ddd	a nap rövid neve (e.g. &apos;Mon&apos; to &apos;Sun&apos;).
+dddd	a nap hosszú neve (e.g. &apos;Monday&apos; to &apos;Sunday&apos;).
+M	a hónap számként bevezető nulla nélkül (1-12)
+MM	a hónap számként bevezető nullával (01-12)
+MMM	a hónap rövid neve (e.g. &apos;Jan&apos; to &apos;Dec&apos;).
+MMMM	a hónap hosszú neve (e.g. &apos;January&apos; to &apos;December&apos;).
+yy	az év két számjeggyel (00-99)
+yyyy	az év négy számjeggyel
+
+MInden más karakter szövegként értelmeződik.
+Sima zárójelbe  (&apos;) tett karaktersorozat szövegként van kezelve,
+tehát az nem kifejezés.
+
+
+Egyéni dátumalak:</translation>
+    </message>
+</context>
+</TS>

--- a/lxqt-panel/plugin-clock/clock_ia.ts
+++ b/lxqt-panel/plugin-clock/clock_ia.ts
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ia">
+<context>
+    <name>FirstDayCombo</name>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="49"/>
+        <source>&lt;locale based&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClock</name>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="57"/>
+        <source>Date&amp;Time (clock) plugin is deprecated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="58"/>
+        <source>The &lt;strong&gt;clock&lt;/strong&gt; plugin is deprecated and will be removed in future version of LXQt. Consider replacing it with &lt;strong&gt;worldclock&lt;/strong&gt;.&lt;br/&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="60"/>
+        <source>don&apos;t show this again</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClockConfiguration</name>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="14"/>
+        <source>Clock Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="20"/>
+        <source>Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="26"/>
+        <source>&amp;Show seconds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="33"/>
+        <source>12 &amp;hour style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="40"/>
+        <source>&amp;Use UTC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="59"/>
+        <source>Date &amp;format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="76"/>
+        <source>&amp;Do not show date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="86"/>
+        <source>Show date &amp;before time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="93"/>
+        <source>Show date &amp;after time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="100"/>
+        <source>Show date below time on new &amp;line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="107"/>
+        <source>First day of week in calendar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="124"/>
+        <source>Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="130"/>
+        <source>Auto&amp;rotate when the panel is vertical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="50"/>
+        <source>Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Input custom date format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Interpreted sequences of date format are:
+
+d	the day as number without a leading zero (1 to 31)
+dd	the day as number with a leading zero (01 to 31)
+ddd	the abbreviated localized day name (e.g. &apos;Mon&apos; to &apos;Sun&apos;).
+dddd	the long localized day name (e.g. &apos;Monday&apos; to &apos;Sunday&apos;).
+M	the month as number without a leading zero (1-12)
+MM	the month as number with a leading zero (01-12)
+MMM	the abbreviated localized month name (e.g. &apos;Jan&apos; to &apos;Dec&apos;).
+MMMM	the long localized month name (e.g. &apos;January&apos; to &apos;December&apos;).
+yy	the year as two digit number (00-99)
+yyyy	the year as four digit number
+
+All other input characters will be treated as text.
+Any sequence of characters that are enclosed in single quotes (&apos;)
+will also be treated as text and not be used as an expression.
+
+
+Custom date format:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/lxqt-panel/plugin-clock/clock_id.ts
+++ b/lxqt-panel/plugin-clock/clock_id.ts
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="id">
+<context>
+    <name>FirstDayCombo</name>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="49"/>
+        <source>&lt;locale based&gt;</source>
+        <translation>&lt;locale based&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClock</name>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="57"/>
+        <source>Date&amp;Time (clock) plugin is deprecated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="58"/>
+        <source>The &lt;strong&gt;clock&lt;/strong&gt; plugin is deprecated and will be removed in future version of LXQt. Consider replacing it with &lt;strong&gt;worldclock&lt;/strong&gt;.&lt;br/&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="60"/>
+        <source>don&apos;t show this again</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClockConfiguration</name>
+    <message>
+        <source>LXQt Clock Settings</source>
+        <translation type="vanished">Pengaturan Jam LXQt</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="14"/>
+        <source>Clock Settings</source>
+        <translation>Pengaturan Jam</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="20"/>
+        <source>Time</source>
+        <translation>Waktu</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="26"/>
+        <source>&amp;Show seconds</source>
+        <translation>Tampilkan detik</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="33"/>
+        <source>12 &amp;hour style</source>
+        <translation>gaya 12 jam</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="40"/>
+        <source>&amp;Use UTC</source>
+        <translation>Gunakan UTC</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="59"/>
+        <source>Date &amp;format</source>
+        <translation>&amp;Format tanggal</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="76"/>
+        <source>&amp;Do not show date</source>
+        <translation>Jangan tampilkan tanggal</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="86"/>
+        <source>Show date &amp;before time</source>
+        <translation>Tampilkan tanggal se&amp;belum waktu</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="93"/>
+        <source>Show date &amp;after time</source>
+        <translation>Tampilkan tanggal setel&amp;ah waktu</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="100"/>
+        <source>Show date below time on new &amp;line</source>
+        <translation>Tampilkan tanggal dibawah waktu di baris baru</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="107"/>
+        <source>First day of week in calendar</source>
+        <translation>Hari pertama dalam seminggu di kalender</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="124"/>
+        <source>Orientation</source>
+        <translation>Orientasi</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="130"/>
+        <source>Auto&amp;rotate when the panel is vertical</source>
+        <translation>Otomatis putar saat panel vertikal</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="50"/>
+        <source>Date</source>
+        <translation>Tanggal</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Input custom date format</source>
+        <translation>Masukkan format tanggal kustom</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Interpreted sequences of date format are:
+
+d	the day as number without a leading zero (1 to 31)
+dd	the day as number with a leading zero (01 to 31)
+ddd	the abbreviated localized day name (e.g. &apos;Mon&apos; to &apos;Sun&apos;).
+dddd	the long localized day name (e.g. &apos;Monday&apos; to &apos;Sunday&apos;).
+M	the month as number without a leading zero (1-12)
+MM	the month as number with a leading zero (01-12)
+MMM	the abbreviated localized month name (e.g. &apos;Jan&apos; to &apos;Dec&apos;).
+MMMM	the long localized month name (e.g. &apos;January&apos; to &apos;December&apos;).
+yy	the year as two digit number (00-99)
+yyyy	the year as four digit number
+
+All other input characters will be treated as text.
+Any sequence of characters that are enclosed in single quotes (&apos;)
+will also be treated as text and not be used as an expression.
+
+
+Custom date format:</source>
+        <translation>Urutan format tanggal yang diinterpretasikan adalah:
+
+h	hari dalam angka tanpa nol didepan (1 sampai 31)
+hh	hari dalam angka dengan nol didepan (01 to 31)
+hhh	nama hari singkat yang dilokalisasi (misal &apos;Min&apos; sampai &apos;Sab&apos;).
+hhhh	nama hari panjang yang dilokalisasi (misal &apos;Minggu&apos; sampai &apos;Sabtu&apos;).
+B	bulan dalam angka tanpa nol didepan (1-12)
+BB	bulan dalam angka dengan nol didepan (01-12)
+BBB	nama bulan singkat yang dilokalisasi (misal &apos;Jan&apos; sampai &apos;Des&apos;).
+BBBB	nama bulan panjang yang dilokalisasi (misal &apos;Januari&apos; sampai &apos;Desember&apos;).
+tt	tahun dalam dua digit angka (00-99)
+tttt	tahun dalam empat digit angka
+
+Semua input karakter lainnya akan diperlakukan sebagai teks.
+Setiap urutan karakter yang diapit tanda kutip tunggal (&apos;) akan
+diperlakukan sebagai teks dan tidak akan digunakan sebagai ekspresi.
+
+
+Kustom format tanggal:</translation>
+    </message>
+</context>
+</TS>

--- a/lxqt-panel/plugin-clock/clock_it.ts
+++ b/lxqt-panel/plugin-clock/clock_it.ts
@@ -1,0 +1,217 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="it">
+<context>
+    <name>FirstDayCombo</name>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="49"/>
+        <source>&lt;locale based&gt;</source>
+        <translation>&lt;basato su locale&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClock</name>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="57"/>
+        <source>Date&amp;Time (clock) plugin is deprecated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="58"/>
+        <source>The &lt;strong&gt;clock&lt;/strong&gt; plugin is deprecated and will be removed in future version of LXQt. Consider replacing it with &lt;strong&gt;worldclock&lt;/strong&gt;.&lt;br/&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="60"/>
+        <source>don&apos;t show this again</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClockConfiguration</name>
+    <message>
+        <source>LXQt Clock Settings</source>
+        <translation type="vanished">Impostazioni dell&apos;orologio di LXQt</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="14"/>
+        <source>Clock Settings</source>
+        <translation>Impostazioni orologio</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="20"/>
+        <source>Time</source>
+        <translation>Ora</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="26"/>
+        <source>&amp;Show seconds</source>
+        <translation>&amp;Mostra i secondi</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="33"/>
+        <source>12 &amp;hour style</source>
+        <translation>&amp;Stile 12 ore</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="40"/>
+        <source>&amp;Use UTC</source>
+        <translation>&amp;Usa UTC</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="59"/>
+        <source>Date &amp;format</source>
+        <translation>Formato &amp;data</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="76"/>
+        <source>&amp;Do not show date</source>
+        <translation>&amp;Non mostrare la data</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="86"/>
+        <source>Show date &amp;before time</source>
+        <translation>Prima la &amp;data</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="93"/>
+        <source>Show date &amp;after time</source>
+        <translation>Prima l&apos;&amp;ora</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="100"/>
+        <source>Show date below time on new &amp;line</source>
+        <translation>Mostra la data su una &amp;seconda riga</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="107"/>
+        <source>First day of week in calendar</source>
+        <translation>Primo giorno della settimana</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="124"/>
+        <source>Orientation</source>
+        <translation>Orientazione</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="130"/>
+        <source>Auto&amp;rotate when the panel is vertical</source>
+        <translation>&amp;Ruota automaticamente se il pannello è verticale</translation>
+    </message>
+    <message>
+        <source>&amp;Font</source>
+        <translation type="vanished">&amp;Carattere</translation>
+    </message>
+    <message>
+        <source>Font</source>
+        <translation type="vanished">Carattere</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="50"/>
+        <source>Date</source>
+        <translation>Data</translation>
+    </message>
+    <message>
+        <source>Show &amp;date</source>
+        <translation type="vanished">Mostra la &amp;data</translation>
+    </message>
+    <message>
+        <source>D&amp;ate format</source>
+        <translation type="vanished">&amp;Formato della data</translation>
+    </message>
+    <message>
+        <source>Fon&amp;t</source>
+        <translation type="vanished">Cara&amp;ttere</translation>
+    </message>
+    <message>
+        <source>Show date in &amp;new line</source>
+        <translation type="vanished">Mostra la data in una &amp;nuova riga</translation>
+    </message>
+    <message>
+        <source>&amp;Use theme fonts</source>
+        <translation type="vanished">&amp;Utilizza i caratteri del tema</translation>
+    </message>
+    <message>
+        <source>Time font</source>
+        <translation type="vanished">Carattere dell&apos;ora</translation>
+    </message>
+    <message>
+        <source>Date font</source>
+        <translation type="vanished">Carattere della data</translation>
+    </message>
+    <message>
+        <source>Ultra light</source>
+        <translation type="vanished">Chiarissimo</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="vanished">Chiaro</translation>
+    </message>
+    <message>
+        <source>Ultra black</source>
+        <translation type="vanished">Nerissimo</translation>
+    </message>
+    <message>
+        <source>Black</source>
+        <translation type="vanished">Nero</translation>
+    </message>
+    <message>
+        <source>Bold</source>
+        <translation type="vanished">Grassetto</translation>
+    </message>
+    <message>
+        <source>Demi bold</source>
+        <translation type="vanished">Neretto</translation>
+    </message>
+    <message>
+        <source>Italic</source>
+        <translation type="vanished">Corsivo</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Input custom date format</source>
+        <translation>Formato personalizzato</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Interpreted sequences of date format are:
+
+d	the day as number without a leading zero (1 to 31)
+dd	the day as number with a leading zero (01 to 31)
+ddd	the abbreviated localized day name (e.g. &apos;Mon&apos; to &apos;Sun&apos;).
+dddd	the long localized day name (e.g. &apos;Monday&apos; to &apos;Sunday&apos;).
+M	the month as number without a leading zero (1-12)
+MM	the month as number with a leading zero (01-12)
+MMM	the abbreviated localized month name (e.g. &apos;Jan&apos; to &apos;Dec&apos;).
+MMMM	the long localized month name (e.g. &apos;January&apos; to &apos;December&apos;).
+yy	the year as two digit number (00-99)
+yyyy	the year as four digit number
+
+All other input characters will be treated as text.
+Any sequence of characters that are enclosed in single quotes (&apos;)
+will also be treated as text and not be used as an expression.
+
+
+Custom date format:</source>
+        <translation>Sequenze interpretate del formato della data sono:
+
+d	il giorno come numero senza uno zero iniziale (da 1 a 31)
+dd	il giorno come numero con uno zero iniziale (da 01 a 31)
+ddd	il nome del giorno localizzato abbreviato (ad es. da &apos;Lun&apos; a &apos;Dom&apos;).
+dddd	il nome del giorno localizzato esteso (ad es. da &apos;Lunedì&apos; a &apos;Domenica&apos;).
+M	il mese come numero senza uno zero iniziale (1-12)
+MM	il mese come numero con uno zero iniziale (01-12)
+MMM	il nome del mese localizzato abbreviato (ad es. da &apos;Gen&apos; a &apos;Dic&apos;).
+MMMM	il nome del mese localizzato esteso (ad es. da &apos;Gennaio&apos; a &apos;Dicembre&apos;).
+yy	l&apos;anno come numero a due cifre (00-99)
+yyyy	l&apos;anno come numero a quattro cifre
+
+Tutti gli altri caratteri saranno trattati come testo.
+Qualsiasi sequenza di caratteri racchiusa tra singoli apici (&apos;)
+sarà trattata come testo e non sarà utilizzata come un&apos;espressione.
+
+
+Formato personalizzato della data:</translation>
+    </message>
+</context>
+</TS>

--- a/lxqt-panel/plugin-clock/clock_ja.ts
+++ b/lxqt-panel/plugin-clock/clock_ja.ts
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ja">
+<context>
+    <name>FirstDayCombo</name>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="49"/>
+        <source>&lt;locale based&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClock</name>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="57"/>
+        <source>Date&amp;Time (clock) plugin is deprecated</source>
+        <translation>日付時刻 (時計) プラグインは非推奨です</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="58"/>
+        <source>The &lt;strong&gt;clock&lt;/strong&gt; plugin is deprecated and will be removed in future version of LXQt. Consider replacing it with &lt;strong&gt;worldclock&lt;/strong&gt;.&lt;br/&gt;</source>
+        <translation>&lt;strong&gt;時計&lt;/strong&gt; プラグインは非推奨であり、将来のバージョンのLXQtで消去される予定です。 &lt;strong&gt;worldclock&lt;/strong&gt;への変更を検討してください。&lt;br/&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="60"/>
+        <source>don&apos;t show this again</source>
+        <translation>二度と表示しない</translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClockConfiguration</name>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="14"/>
+        <source>Clock Settings</source>
+        <translation>時計の設定</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="20"/>
+        <source>Time</source>
+        <translation>時刻</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="26"/>
+        <source>&amp;Show seconds</source>
+        <translation>秒を表示(&amp;S)</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="33"/>
+        <source>12 &amp;hour style</source>
+        <translation>12時間表示(&amp;H)</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="40"/>
+        <source>&amp;Use UTC</source>
+        <translation>UTCを使用する(&amp;U)</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="59"/>
+        <source>Date &amp;format</source>
+        <translation>日時の形式(&amp;F)</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="76"/>
+        <source>&amp;Do not show date</source>
+        <translation>日付を表示しない(&amp;D)</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="86"/>
+        <source>Show date &amp;before time</source>
+        <translation>日付のあとに時刻(&amp;B)</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="93"/>
+        <source>Show date &amp;after time</source>
+        <translation>時刻のあとに日付(&amp;A)</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="100"/>
+        <source>Show date below time on new &amp;line</source>
+        <translation>時刻の下に日付(&amp;L)</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="107"/>
+        <source>First day of week in calendar</source>
+        <translation>カレンダーの最初の日付</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="124"/>
+        <source>Orientation</source>
+        <translation>回転</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="130"/>
+        <source>Auto&amp;rotate when the panel is vertical</source>
+        <translation>パネルが縦のときに自動回転(&amp;R)</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="50"/>
+        <source>Date</source>
+        <translation>日付</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Input custom date format</source>
+        <translation>日付の表示形式を指定</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Interpreted sequences of date format are:
+
+d	the day as number without a leading zero (1 to 31)
+dd	the day as number with a leading zero (01 to 31)
+ddd	the abbreviated localized day name (e.g. &apos;Mon&apos; to &apos;Sun&apos;).
+dddd	the long localized day name (e.g. &apos;Monday&apos; to &apos;Sunday&apos;).
+M	the month as number without a leading zero (1-12)
+MM	the month as number with a leading zero (01-12)
+MMM	the abbreviated localized month name (e.g. &apos;Jan&apos; to &apos;Dec&apos;).
+MMMM	the long localized month name (e.g. &apos;January&apos; to &apos;December&apos;).
+yy	the year as two digit number (00-99)
+yyyy	the year as four digit number
+
+All other input characters will be treated as text.
+Any sequence of characters that are enclosed in single quotes (&apos;)
+will also be treated as text and not be used as an expression.
+
+
+Custom date format:</source>
+        <translation>解釈される記法:
+
+d	日(ゼロなし) (1 - 31)
+dd	日(ゼロ埋め) (01 - 31)
+ddd	 曜日（短い） (&apos;月&apos; - &apos;日&apos;)
+dddd	曜日（長い） (&apos;月曜日&apos; - &apos;日曜日&apos;)
+M	月（ゼロなし） (1 - 12)
+MM	月（ゼロ埋め） (01 - 12)
+MMM	月の名称（短い） (&apos;1月&apos; - &apos;12月&apos;)
+MMMM	月の名称 (長い） (&apos;1月&apos; - &apos;12月&apos;、※日本語では上記と同じ)
+yy	西暦年(2桁) (00 - 99)
+yyyy	西暦年(4桁)
+
+そのほかの文字は解釈されず、テキストとして表示されます。
+上記の解釈される文字も、シングルクオーテーション(&apos;)で括ると
+一般の文字として扱われ、上記の解釈はされません。
+
+
+日付形式の指定:</translation>
+    </message>
+</context>
+</TS>

--- a/lxqt-panel/plugin-clock/clock_ko.ts
+++ b/lxqt-panel/plugin-clock/clock_ko.ts
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ko">
+<context>
+    <name>FirstDayCombo</name>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="49"/>
+        <source>&lt;locale based&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClock</name>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="57"/>
+        <source>Date&amp;Time (clock) plugin is deprecated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="58"/>
+        <source>The &lt;strong&gt;clock&lt;/strong&gt; plugin is deprecated and will be removed in future version of LXQt. Consider replacing it with &lt;strong&gt;worldclock&lt;/strong&gt;.&lt;br/&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="60"/>
+        <source>don&apos;t show this again</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClockConfiguration</name>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="14"/>
+        <source>Clock Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="20"/>
+        <source>Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="26"/>
+        <source>&amp;Show seconds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="33"/>
+        <source>12 &amp;hour style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="40"/>
+        <source>&amp;Use UTC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="59"/>
+        <source>Date &amp;format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="76"/>
+        <source>&amp;Do not show date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="86"/>
+        <source>Show date &amp;before time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="93"/>
+        <source>Show date &amp;after time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="100"/>
+        <source>Show date below time on new &amp;line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="107"/>
+        <source>First day of week in calendar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="124"/>
+        <source>Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="130"/>
+        <source>Auto&amp;rotate when the panel is vertical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="50"/>
+        <source>Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Input custom date format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Interpreted sequences of date format are:
+
+d	the day as number without a leading zero (1 to 31)
+dd	the day as number with a leading zero (01 to 31)
+ddd	the abbreviated localized day name (e.g. &apos;Mon&apos; to &apos;Sun&apos;).
+dddd	the long localized day name (e.g. &apos;Monday&apos; to &apos;Sunday&apos;).
+M	the month as number without a leading zero (1-12)
+MM	the month as number with a leading zero (01-12)
+MMM	the abbreviated localized month name (e.g. &apos;Jan&apos; to &apos;Dec&apos;).
+MMMM	the long localized month name (e.g. &apos;January&apos; to &apos;December&apos;).
+yy	the year as two digit number (00-99)
+yyyy	the year as four digit number
+
+All other input characters will be treated as text.
+Any sequence of characters that are enclosed in single quotes (&apos;)
+will also be treated as text and not be used as an expression.
+
+
+Custom date format:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/lxqt-panel/plugin-clock/clock_lt.ts
+++ b/lxqt-panel/plugin-clock/clock_lt.ts
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="lt">
+<context>
+    <name>FirstDayCombo</name>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="49"/>
+        <source>&lt;locale based&gt;</source>
+        <translation>&lt;pagal lokalę&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClock</name>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="57"/>
+        <source>Date&amp;Time (clock) plugin is deprecated</source>
+        <translation>Datos ir laiko (laikrodžio) įskiepis yra apleistas</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="58"/>
+        <source>The &lt;strong&gt;clock&lt;/strong&gt; plugin is deprecated and will be removed in future version of LXQt. Consider replacing it with &lt;strong&gt;worldclock&lt;/strong&gt;.&lt;br/&gt;</source>
+        <translation>&lt;strong&gt;Laikrodžio&lt;/strong&gt; įskiepis yra apleistas ir būsimosiose LXQt versijose bus pašalintas. Apsvarstykite galimybę jį pakeisti &lt;strong&gt;pasaulio laikrodžių&lt;/strong&gt; įskiepiu.&lt;br/&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="60"/>
+        <source>don&apos;t show this again</source>
+        <translation>daugiau neberodyti</translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClockConfiguration</name>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="14"/>
+        <source>Clock Settings</source>
+        <translation>Laikrodžio nustatymai</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="20"/>
+        <source>Time</source>
+        <translation>Laikas</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="26"/>
+        <source>&amp;Show seconds</source>
+        <translation>&amp;Rodyti sekundes</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="33"/>
+        <source>12 &amp;hour style</source>
+        <translation>12 &amp;valandų stilius</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="40"/>
+        <source>&amp;Use UTC</source>
+        <translation>&amp;Naudoti suderintąjį pasaulinį laiką (UTC)</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="76"/>
+        <source>&amp;Do not show date</source>
+        <translation>&amp;Nerodyti datą</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="86"/>
+        <source>Show date &amp;before time</source>
+        <translation>Rodyti datą pr&amp;ieš laiką</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="93"/>
+        <source>Show date &amp;after time</source>
+        <translation>Rodyti datą p&amp;o laiko</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="100"/>
+        <source>Show date below time on new &amp;line</source>
+        <translation>Rodyti datą žemiau laiko, naujoje ei&amp;lutėje</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="107"/>
+        <source>First day of week in calendar</source>
+        <translation>Pirma savaitės diena kalendoriuje</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="124"/>
+        <source>Orientation</source>
+        <translation>Orientacija</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="130"/>
+        <source>Auto&amp;rotate when the panel is vertical</source>
+        <translation>Automatiškai pa&amp;sukti, kai skydelis yra vertikalus</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="50"/>
+        <source>Date</source>
+        <translation>Data</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="59"/>
+        <source>Date &amp;format</source>
+        <translation>Datos &amp;formatas</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Input custom date format</source>
+        <translation>Įveskite tinkintą datos formatą</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Interpreted sequences of date format are:
+
+d	the day as number without a leading zero (1 to 31)
+dd	the day as number with a leading zero (01 to 31)
+ddd	the abbreviated localized day name (e.g. &apos;Mon&apos; to &apos;Sun&apos;).
+dddd	the long localized day name (e.g. &apos;Monday&apos; to &apos;Sunday&apos;).
+M	the month as number without a leading zero (1-12)
+MM	the month as number with a leading zero (01-12)
+MMM	the abbreviated localized month name (e.g. &apos;Jan&apos; to &apos;Dec&apos;).
+MMMM	the long localized month name (e.g. &apos;January&apos; to &apos;December&apos;).
+yy	the year as two digit number (00-99)
+yyyy	the year as four digit number
+
+All other input characters will be treated as text.
+Any sequence of characters that are enclosed in single quotes (&apos;)
+will also be treated as text and not be used as an expression.
+
+
+Custom date format:</source>
+        <translation>Suprantamos datos formato sekos yra:
+
+d	diena kaip skaičius be priekinio nulio (1 iki 31)
+dd	diena kaip skaičius su priekiniu nuliu (01 iki 31)
+ddd	sutrumpintas lokalizuotas dienos pavadinimas (pvz., &quot;Pir&quot; iki &quot;Sek&quot;).
+dddd	ilgas lokalizuotas dienos pavadinimas (pvz., &quot;Pirmadienis&quot; iki &quot;Sekmadienis&quot;).
+M	mėnesis kaip skaičius be priekinio nulio (1-12)
+MM	mėnesis kaip skaičius su priekiniu nuliu (01-12)
+MMM	sutrumpintas lokalizuotas mėnesio pavadinimas (pvz., &quot;Sau&quot; iki &quot;Gru&quot;).
+MMMM	ilgas lokalizuotas mėnesio pavadinimas (pvz., &quot;Sausis&quot; iki &quot;Gruodis&quot;).
+yy	metai kaip dviejų skaitmenų skaičius (00-99)
+yyyy	metai kaip keturių skaitmenų skaičius
+
+Visi kiti įvesti simboliai bus laikomi tekstu.
+Bet kokia simbolių seka, patalpinta į kabutes (&apos;),
+taip pat bus laikoma tekstu ir nebus naudojama kaip reiškinys.
+
+
+Tinkintas datos formatas:</translation>
+    </message>
+</context>
+</TS>

--- a/lxqt-panel/plugin-clock/clock_nl.ts
+++ b/lxqt-panel/plugin-clock/clock_nl.ts
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="nl">
+<context>
+    <name>FirstDayCombo</name>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="49"/>
+        <source>&lt;locale based&gt;</source>
+        <translation>&lt;Gebaseerd op regionale instellingen&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClock</name>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="57"/>
+        <source>Date&amp;Time (clock) plugin is deprecated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="58"/>
+        <source>The &lt;strong&gt;clock&lt;/strong&gt; plugin is deprecated and will be removed in future version of LXQt. Consider replacing it with &lt;strong&gt;worldclock&lt;/strong&gt;.&lt;br/&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="60"/>
+        <source>don&apos;t show this again</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClockConfiguration</name>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="14"/>
+        <source>Clock Settings</source>
+        <translation>Klokinstellingen</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="20"/>
+        <source>Time</source>
+        <translation>Tijd</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="26"/>
+        <source>&amp;Show seconds</source>
+        <translation>&amp;Toon seconden</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="33"/>
+        <source>12 &amp;hour style</source>
+        <translation>12-uurs-&amp;klokstijl</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="40"/>
+        <source>&amp;Use UTC</source>
+        <translation>&amp;Gebruik UTC</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="50"/>
+        <source>Date</source>
+        <translation>Datum</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="59"/>
+        <source>Date &amp;format</source>
+        <translation>Datums&amp;vormgeving</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="76"/>
+        <source>&amp;Do not show date</source>
+        <translation>&amp;Toon datum niet</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="86"/>
+        <source>Show date &amp;before time</source>
+        <translation>Datum &amp;vor Zeit anzeigen</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="93"/>
+        <source>Show date &amp;after time</source>
+        <translation>Toon datum &amp;achter tijd</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="100"/>
+        <source>Show date below time on new &amp;line</source>
+        <translation>Toon datum &amp;onder tijd op nieuwe regel</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="107"/>
+        <source>First day of week in calendar</source>
+        <translation>Eerste weekdag in de kalender</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="124"/>
+        <source>Orientation</source>
+        <translation>Oriëntatie</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="130"/>
+        <source>Auto&amp;rotate when the panel is vertical</source>
+        <translation>Automatisch d&amp;raaien bij verticale werkbalk</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Input custom date format</source>
+        <translation>Aangepaste datumvormgeving</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Interpreted sequences of date format are:
+
+d	the day as number without a leading zero (1 to 31)
+dd	the day as number with a leading zero (01 to 31)
+ddd	the abbreviated localized day name (e.g. &apos;Mon&apos; to &apos;Sun&apos;).
+dddd	the long localized day name (e.g. &apos;Monday&apos; to &apos;Sunday&apos;).
+M	the month as number without a leading zero (1-12)
+MM	the month as number with a leading zero (01-12)
+MMM	the abbreviated localized month name (e.g. &apos;Jan&apos; to &apos;Dec&apos;).
+MMMM	the long localized month name (e.g. &apos;January&apos; to &apos;December&apos;).
+yy	the year as two digit number (00-99)
+yyyy	the year as four digit number
+
+All other input characters will be treated as text.
+Any sequence of characters that are enclosed in single quotes (&apos;)
+will also be treated as text and not be used as an expression.
+
+
+Custom date format:</source>
+        <translation>Toegestane soorten van datumvormgeving zijn:
+
+d	Dag als getal zonder voorafgaande nul (1 tot 31)
+dd	Dag als getal met voorafgaande nul (01 tot 31)
+ddd	Afgekorte regionale dagnaam (bijv. &apos;ma&apos; tot &apos;zon&apos;).
+dddd	Volledige regionale dagnaam (bijv. &apos;maandag&apos; tot &apos;zondag&apos;).
+M	Maand als getal zonder voorafgaande nul (1-12)
+MM	Maand als getal met voorafgaande nul (01-12)
+MMM	Afgekorte regionale maandnaam (bijv. &apos;jan&apos; tot &apos;dec&apos;).
+MMMM	Volledige regionale maandnaam (bijv. &apos;januari&apos; tot &apos;december&apos;).
+yy	Jaar als tweecijferig getal (00-99)
+yyyy	Jaar als viercijferig getal
+
+Alle andere ingevoerde tekens zullen worden behandeld als tekst.
+Elke volgorde van gegevens die tussen enkele aanhalingstekens (&apos;) staan,
+zal eveneens worden behandeld als tekst en niet worden gebruikt als een uitdrukking.
+
+
+Eigen datumvormgeving:</translation>
+    </message>
+</context>
+</TS>

--- a/lxqt-panel/plugin-clock/clock_pl.ts
+++ b/lxqt-panel/plugin-clock/clock_pl.ts
@@ -1,0 +1,199 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pl">
+<context>
+    <name>FirstDayCombo</name>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="49"/>
+        <source>&lt;locale based&gt;</source>
+        <translation>&lt;zależny od języka&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClock</name>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="57"/>
+        <source>Date&amp;Time (clock) plugin is deprecated</source>
+        <translation>Wtyczka Czas i data została porzucona</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="58"/>
+        <source>The &lt;strong&gt;clock&lt;/strong&gt; plugin is deprecated and will be removed in future version of LXQt. Consider replacing it with &lt;strong&gt;worldclock&lt;/strong&gt;.&lt;br/&gt;</source>
+        <translation>Wtyczka &lt;strong&gt;clock&lt;/strong&gt; została porzucona i zostanie usunięta w przyszłej wersji LXQt. Zalecane jest korzystanie z &lt;strong&gt;worldclock&lt;/strong&gt;.&lt;br/&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="60"/>
+        <source>don&apos;t show this again</source>
+        <translation>Nie pokazuj ponownie tego komunikatu</translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClockConfiguration</name>
+    <message>
+        <source>LXQt Clock Settings</source>
+        <translation type="vanished">Ustawienia zegara LXQt</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="14"/>
+        <source>Clock Settings</source>
+        <translation>Ustawienia zegara</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="20"/>
+        <source>Time</source>
+        <translation>Czas</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="26"/>
+        <source>&amp;Show seconds</source>
+        <translation>&amp;Pokaż sekundy</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="33"/>
+        <source>12 &amp;hour style</source>
+        <translation>12 &amp;godzinny styl</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="40"/>
+        <source>&amp;Use UTC</source>
+        <translation>&amp;Użyj UTC</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="59"/>
+        <source>Date &amp;format</source>
+        <translation>&amp;Format daty</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="76"/>
+        <source>&amp;Do not show date</source>
+        <translation>&amp;Nie pokazuj daty</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="86"/>
+        <source>Show date &amp;before time</source>
+        <translation>Poka&amp;ż datę przed godziną</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="93"/>
+        <source>Show date &amp;after time</source>
+        <translation>Pokaż datę &amp;za godziną</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="100"/>
+        <source>Show date below time on new &amp;line</source>
+        <translation>Pokaż datę pod godziną w nowej &amp;linii</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="107"/>
+        <source>First day of week in calendar</source>
+        <translation>Pierwszy dzień tygodnia w kalendarzu</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="124"/>
+        <source>Orientation</source>
+        <translation>Orientacja</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="130"/>
+        <source>Auto&amp;rotate when the panel is vertical</source>
+        <translation>Ob&amp;róć gdy panel jest pionowy</translation>
+    </message>
+    <message>
+        <source>&amp;Font</source>
+        <translation type="vanished">&amp;Czcionka</translation>
+    </message>
+    <message>
+        <source>Font</source>
+        <translation type="vanished">Czcionka</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="50"/>
+        <source>Date</source>
+        <translation>Data</translation>
+    </message>
+    <message>
+        <source>Show &amp;date</source>
+        <translation type="vanished">Pokaż &amp;date</translation>
+    </message>
+    <message>
+        <source>D&amp;ate format</source>
+        <translation type="vanished">Format C&amp;zasu</translation>
+    </message>
+    <message>
+        <source>Fon&amp;t</source>
+        <translation type="vanished">Czcionk&amp;a</translation>
+    </message>
+    <message>
+        <source>Show date in &amp;new line</source>
+        <translation type="vanished">Pokaż datę w &amp;nowej linii</translation>
+    </message>
+    <message>
+        <source>&amp;Use theme fonts</source>
+        <translation type="vanished">&amp;Użyj motywów czcionek</translation>
+    </message>
+    <message>
+        <source>Time font</source>
+        <translation type="vanished">Czcionka czasu</translation>
+    </message>
+    <message>
+        <source>Date font</source>
+        <translation type="vanished">Czcionka daty</translation>
+    </message>
+    <message>
+        <source>Ultra light</source>
+        <translation type="vanished">Bardzo cienka</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="vanished">Cienka</translation>
+    </message>
+    <message>
+        <source>Ultra black</source>
+        <translation type="vanished">Bardzo czarna</translation>
+    </message>
+    <message>
+        <source>Black</source>
+        <translation type="vanished">Czarna</translation>
+    </message>
+    <message>
+        <source>Bold</source>
+        <translation type="vanished">Pogrubiona</translation>
+    </message>
+    <message>
+        <source>Demi bold</source>
+        <translation type="vanished">Wpół pogrubiona</translation>
+    </message>
+    <message>
+        <source>Italic</source>
+        <translation type="vanished">Kursywa</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Input custom date format</source>
+        <translation>Własny format daty</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Interpreted sequences of date format are:
+
+d	the day as number without a leading zero (1 to 31)
+dd	the day as number with a leading zero (01 to 31)
+ddd	the abbreviated localized day name (e.g. &apos;Mon&apos; to &apos;Sun&apos;).
+dddd	the long localized day name (e.g. &apos;Monday&apos; to &apos;Sunday&apos;).
+M	the month as number without a leading zero (1-12)
+MM	the month as number with a leading zero (01-12)
+MMM	the abbreviated localized month name (e.g. &apos;Jan&apos; to &apos;Dec&apos;).
+MMMM	the long localized month name (e.g. &apos;January&apos; to &apos;December&apos;).
+yy	the year as two digit number (00-99)
+yyyy	the year as four digit number
+
+All other input characters will be treated as text.
+Any sequence of characters that are enclosed in single quotes (&apos;)
+will also be treated as text and not be used as an expression.
+
+
+Custom date format:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/lxqt-panel/plugin-clock/clock_pt.ts
+++ b/lxqt-panel/plugin-clock/clock_pt.ts
@@ -1,0 +1,217 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt">
+<context>
+    <name>FirstDayCombo</name>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="49"/>
+        <source>&lt;locale based&gt;</source>
+        <translation>&lt;baseado na configuração regional&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClock</name>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="57"/>
+        <source>Date&amp;Time (clock) plugin is deprecated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="58"/>
+        <source>The &lt;strong&gt;clock&lt;/strong&gt; plugin is deprecated and will be removed in future version of LXQt. Consider replacing it with &lt;strong&gt;worldclock&lt;/strong&gt;.&lt;br/&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="60"/>
+        <source>don&apos;t show this again</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClockConfiguration</name>
+    <message>
+        <source>LXQt Clock Settings</source>
+        <translation type="vanished">Definições do relógio LXQt</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="14"/>
+        <source>Clock Settings</source>
+        <translation>Definições do relógio</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="20"/>
+        <source>Time</source>
+        <translation>Horas</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="26"/>
+        <source>&amp;Show seconds</source>
+        <translation>Mo&amp;strar segundos</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="33"/>
+        <source>12 &amp;hour style</source>
+        <translation>Estilo 12 &amp;horas</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="40"/>
+        <source>&amp;Use UTC</source>
+        <translation>Usar &amp;UTC</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="59"/>
+        <source>Date &amp;format</source>
+        <translation>&amp;Formato de data</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="76"/>
+        <source>&amp;Do not show date</source>
+        <translation>Não mostrar &amp;data</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="86"/>
+        <source>Show date &amp;before time</source>
+        <translation>Mostrar data &amp;antes das horas</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="93"/>
+        <source>Show date &amp;after time</source>
+        <translation>Mostrar data depois d&amp;as horas</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="100"/>
+        <source>Show date below time on new &amp;line</source>
+        <translation>Mostrar data por &amp;baixo das horas</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="107"/>
+        <source>First day of week in calendar</source>
+        <translation>Primeiro dia da semana</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="124"/>
+        <source>Orientation</source>
+        <translation>Orientação</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="130"/>
+        <source>Auto&amp;rotate when the panel is vertical</source>
+        <translation>&amp;Rodar automaticamente se o painel for vertical</translation>
+    </message>
+    <message>
+        <source>&amp;Font</source>
+        <translation type="vanished">Tipo &amp;de letra</translation>
+    </message>
+    <message>
+        <source>Font</source>
+        <translation type="vanished">Tipo de letra</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="50"/>
+        <source>Date</source>
+        <translation>Data</translation>
+    </message>
+    <message>
+        <source>Show &amp;date</source>
+        <translation type="vanished">Mostrar &amp;data</translation>
+    </message>
+    <message>
+        <source>D&amp;ate format</source>
+        <translation type="vanished">Form&amp;ato da data</translation>
+    </message>
+    <message>
+        <source>Fon&amp;t</source>
+        <translation type="vanished">&amp;Tipo de letra</translation>
+    </message>
+    <message>
+        <source>Show date in &amp;new line</source>
+        <translation type="vanished">Mostrar data em linha disti&amp;nta</translation>
+    </message>
+    <message>
+        <source>&amp;Use theme fonts</source>
+        <translation type="vanished">&amp;Utilizar tipo de letra do tema</translation>
+    </message>
+    <message>
+        <source>Time font</source>
+        <translation type="vanished">Tipo de letra das horas</translation>
+    </message>
+    <message>
+        <source>Date font</source>
+        <translation type="vanished">Tipo de letra da data</translation>
+    </message>
+    <message>
+        <source>Ultra light</source>
+        <translation type="vanished">Mais clara</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="vanished">Clara</translation>
+    </message>
+    <message>
+        <source>Ultra black</source>
+        <translation type="vanished">Normal carregado</translation>
+    </message>
+    <message>
+        <source>Black</source>
+        <translation type="vanished">Normal</translation>
+    </message>
+    <message>
+        <source>Bold</source>
+        <translation type="vanished">Negrito</translation>
+    </message>
+    <message>
+        <source>Demi bold</source>
+        <translation type="vanished">Negrito suave</translation>
+    </message>
+    <message>
+        <source>Italic</source>
+        <translation type="vanished">Itálico</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Input custom date format</source>
+        <translation>Formato personalizado de data</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Interpreted sequences of date format are:
+
+d	the day as number without a leading zero (1 to 31)
+dd	the day as number with a leading zero (01 to 31)
+ddd	the abbreviated localized day name (e.g. &apos;Mon&apos; to &apos;Sun&apos;).
+dddd	the long localized day name (e.g. &apos;Monday&apos; to &apos;Sunday&apos;).
+M	the month as number without a leading zero (1-12)
+MM	the month as number with a leading zero (01-12)
+MMM	the abbreviated localized month name (e.g. &apos;Jan&apos; to &apos;Dec&apos;).
+MMMM	the long localized month name (e.g. &apos;January&apos; to &apos;December&apos;).
+yy	the year as two digit number (00-99)
+yyyy	the year as four digit number
+
+All other input characters will be treated as text.
+Any sequence of characters that are enclosed in single quotes (&apos;)
+will also be treated as text and not be used as an expression.
+
+
+Custom date format:</source>
+        <translation>As sequências possíveis para o formato de data são as seguintes:
+
+d	o dia da semana sem o zero inicial (1 a 31)
+dd	o dia da semana com o zero inicial (01 a 31)
+ddd	o nome abreviado do dia da semana (seg a dom)
+dddd	o nome completo do dia da semana (segunda-feira a domingo)
+M	o mês, como número e sem o zero inicial (1 a12)
+MM	o mês, como número e com o zero inicial (01 a 12)
+MMM	o nome abreviado do mês (jan a dez)
+MMMM	o nome completo do mês (janeiro a dezembro)
+yy	o ano no formato de dois dígitos (00 a 99)
+yyyy	o ano no formato de quatro dígitos
+
+Todas as outras sequências de caracteres serão tratadas como texto.
+Quaisquer sequências de caracteres entre apóstrofos (&apos;) também
+serão tratadas como texto e não serão utilizadas como expressão.
+
+
+Formato personalizado:</translation>
+    </message>
+</context>
+</TS>

--- a/lxqt-panel/plugin-clock/clock_pt_BR.ts
+++ b/lxqt-panel/plugin-clock/clock_pt_BR.ts
@@ -1,0 +1,199 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt_BR">
+<context>
+    <name>FirstDayCombo</name>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="49"/>
+        <source>&lt;locale based&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClock</name>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="57"/>
+        <source>Date&amp;Time (clock) plugin is deprecated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="58"/>
+        <source>The &lt;strong&gt;clock&lt;/strong&gt; plugin is deprecated and will be removed in future version of LXQt. Consider replacing it with &lt;strong&gt;worldclock&lt;/strong&gt;.&lt;br/&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="60"/>
+        <source>don&apos;t show this again</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClockConfiguration</name>
+    <message>
+        <source>LXQt Clock Settings</source>
+        <translation type="vanished">Configurações do relógio do LXQt</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="14"/>
+        <source>Clock Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="20"/>
+        <source>Time</source>
+        <translation>Hora</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="26"/>
+        <source>&amp;Show seconds</source>
+        <translation>&amp;Mostrar segundos</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="33"/>
+        <source>12 &amp;hour style</source>
+        <translation>Estilo 12 &amp;horas</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="40"/>
+        <source>&amp;Use UTC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="59"/>
+        <source>Date &amp;format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="76"/>
+        <source>&amp;Do not show date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="86"/>
+        <source>Show date &amp;before time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="93"/>
+        <source>Show date &amp;after time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="100"/>
+        <source>Show date below time on new &amp;line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="107"/>
+        <source>First day of week in calendar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="124"/>
+        <source>Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="130"/>
+        <source>Auto&amp;rotate when the panel is vertical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Font</source>
+        <translation type="vanished">&amp;Fonte</translation>
+    </message>
+    <message>
+        <source>Font</source>
+        <translation type="vanished">Fonte</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="50"/>
+        <source>Date</source>
+        <translation>Data</translation>
+    </message>
+    <message>
+        <source>Show &amp;date</source>
+        <translation type="vanished">Mostrar &amp;data</translation>
+    </message>
+    <message>
+        <source>D&amp;ate format</source>
+        <translation type="vanished">Formato da d&amp;ata</translation>
+    </message>
+    <message>
+        <source>Fon&amp;t</source>
+        <translation type="vanished">Fon&amp;te</translation>
+    </message>
+    <message>
+        <source>Show date in &amp;new line</source>
+        <translation type="vanished">Mostrar data em &amp;nova linha</translation>
+    </message>
+    <message>
+        <source>&amp;Use theme fonts</source>
+        <translation type="vanished">&amp;Utilizar fontes do tema</translation>
+    </message>
+    <message>
+        <source>Time font</source>
+        <translation type="vanished">Fonte da hora</translation>
+    </message>
+    <message>
+        <source>Date font</source>
+        <translation type="vanished">Fonte da data</translation>
+    </message>
+    <message>
+        <source>Ultra light</source>
+        <translation type="vanished">Super claro</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="vanished">Claro</translation>
+    </message>
+    <message>
+        <source>Ultra black</source>
+        <translation type="vanished">Super escuro</translation>
+    </message>
+    <message>
+        <source>Black</source>
+        <translation type="vanished">Escuro</translation>
+    </message>
+    <message>
+        <source>Bold</source>
+        <translation type="vanished">Negrito</translation>
+    </message>
+    <message>
+        <source>Demi bold</source>
+        <translation type="vanished">Semi negrito</translation>
+    </message>
+    <message>
+        <source>Italic</source>
+        <translation type="vanished">Itálico</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Input custom date format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Interpreted sequences of date format are:
+
+d	the day as number without a leading zero (1 to 31)
+dd	the day as number with a leading zero (01 to 31)
+ddd	the abbreviated localized day name (e.g. &apos;Mon&apos; to &apos;Sun&apos;).
+dddd	the long localized day name (e.g. &apos;Monday&apos; to &apos;Sunday&apos;).
+M	the month as number without a leading zero (1-12)
+MM	the month as number with a leading zero (01-12)
+MMM	the abbreviated localized month name (e.g. &apos;Jan&apos; to &apos;Dec&apos;).
+MMMM	the long localized month name (e.g. &apos;January&apos; to &apos;December&apos;).
+yy	the year as two digit number (00-99)
+yyyy	the year as four digit number
+
+All other input characters will be treated as text.
+Any sequence of characters that are enclosed in single quotes (&apos;)
+will also be treated as text and not be used as an expression.
+
+
+Custom date format:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/lxqt-panel/plugin-clock/clock_ro_RO.ts
+++ b/lxqt-panel/plugin-clock/clock_ro_RO.ts
@@ -1,0 +1,165 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ro_RO">
+<context>
+    <name>FirstDayCombo</name>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="49"/>
+        <source>&lt;locale based&gt;</source>
+        <translation type="unfinished">&lt;bazat pe localizare&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClock</name>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="57"/>
+        <source>Date&amp;Time (clock) plugin is deprecated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="58"/>
+        <source>The &lt;strong&gt;clock&lt;/strong&gt; plugin is deprecated and will be removed in future version of LXQt. Consider replacing it with &lt;strong&gt;worldclock&lt;/strong&gt;.&lt;br/&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="60"/>
+        <source>don&apos;t show this again</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClockConfiguration</name>
+    <message>
+        <source>LXQt Clock Settings</source>
+        <translation type="vanished">Setări ceas LXQt</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="14"/>
+        <source>Clock Settings</source>
+        <translation type="unfinished">Setări ceas</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="20"/>
+        <source>Time</source>
+        <translation>Oră</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="26"/>
+        <source>&amp;Show seconds</source>
+        <translation>Afișează &amp;secundele</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="33"/>
+        <source>12 &amp;hour style</source>
+        <translation>Stil 12 de &amp;ore</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="40"/>
+        <source>&amp;Use UTC</source>
+        <translation type="unfinished">&amp;Utilizează UTC</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="59"/>
+        <source>Date &amp;format</source>
+        <translation type="unfinished">&amp;Formatul datei</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="76"/>
+        <source>&amp;Do not show date</source>
+        <translation type="unfinished">&amp;Nu afișa data</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="86"/>
+        <source>Show date &amp;before time</source>
+        <translation type="unfinished">Afișează data &amp;înaintea orei</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="93"/>
+        <source>Show date &amp;after time</source>
+        <translation type="unfinished">Afișează data &amp;după timp</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="100"/>
+        <source>Show date below time on new &amp;line</source>
+        <translation type="unfinished">Afișează data pe un &amp;rând nou sub oră</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="107"/>
+        <source>First day of week in calendar</source>
+        <translation type="unfinished">Prima zi a săptămânii</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="124"/>
+        <source>Orientation</source>
+        <translation type="unfinished">Orientare</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="130"/>
+        <source>Auto&amp;rotate when the panel is vertical</source>
+        <translation type="unfinished">Rotire automată când panoul e vertical</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="50"/>
+        <source>Date</source>
+        <translation>Dată</translation>
+    </message>
+    <message>
+        <source>Show &amp;date</source>
+        <translation type="vanished">Afișează &amp;data</translation>
+    </message>
+    <message>
+        <source>D&amp;ate format</source>
+        <translation type="vanished">Format d&amp;ată</translation>
+    </message>
+    <message>
+        <source>Show date in &amp;new line</source>
+        <translation type="vanished">Afișează data pe rând &amp;nou</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Input custom date format</source>
+        <translation type="unfinished">Format de dată personalizat</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Interpreted sequences of date format are:
+
+d	the day as number without a leading zero (1 to 31)
+dd	the day as number with a leading zero (01 to 31)
+ddd	the abbreviated localized day name (e.g. &apos;Mon&apos; to &apos;Sun&apos;).
+dddd	the long localized day name (e.g. &apos;Monday&apos; to &apos;Sunday&apos;).
+M	the month as number without a leading zero (1-12)
+MM	the month as number with a leading zero (01-12)
+MMM	the abbreviated localized month name (e.g. &apos;Jan&apos; to &apos;Dec&apos;).
+MMMM	the long localized month name (e.g. &apos;January&apos; to &apos;December&apos;).
+yy	the year as two digit number (00-99)
+yyyy	the year as four digit number
+
+All other input characters will be treated as text.
+Any sequence of characters that are enclosed in single quotes (&apos;)
+will also be treated as text and not be used as an expression.
+
+
+Custom date format:</source>
+        <translation type="unfinished">Secvențe interpretate pentru formatarea datei sunt:
+
+d   numărul zilei fără zero în față  (între 1 și 31)
+dd  numărul zilei cu zero în față (între 01 și 31)
+ddd numele abreviat al zilei (de ex. &apos;Lu&apos; până &apos;Du&apos;).
+dddd    numele lung al zilei (de ex. &apos;Luni&apos; până &apos;Duminică&apos;).
+M   numărul lunii fără zero în față (1-12)
+MM  numărul lunii cu zero în față (01-12)
+MMM numele abreviat și localizat al lunii (de ex. &apos;Ian&apos; - &apos;Dec&apos;).
+MMMM    numele lung și localizat al lunii (de ex. &apos;Ianuarie&apos; - &apos;December&apos;).
+yy  anul ca un număr din 2 cifre (00-99)
+yyyy    anul ca un număr din 4 cifre
+
+Orice alt caracter introdus va fi tratat ca text.
+Orice secvență de caractere intre ghilimele simple (&apos;)
+vor fi la fel tratate ca text si nu vor fi interpretate in expresie.
+
+
+Format de dată personalizat:</translation>
+    </message>
+</context>
+</TS>

--- a/lxqt-panel/plugin-clock/clock_ru.ts
+++ b/lxqt-panel/plugin-clock/clock_ru.ts
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ru">
+<context>
+    <name>FirstDayCombo</name>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="49"/>
+        <source>&lt;locale based&gt;</source>
+        <translation>&lt;настройки локали&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClock</name>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="57"/>
+        <source>Date&amp;Time (clock) plugin is deprecated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="58"/>
+        <source>The &lt;strong&gt;clock&lt;/strong&gt; plugin is deprecated and will be removed in future version of LXQt. Consider replacing it with &lt;strong&gt;worldclock&lt;/strong&gt;.&lt;br/&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="60"/>
+        <source>don&apos;t show this again</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClockConfiguration</name>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="14"/>
+        <source>Clock Settings</source>
+        <translation>Настройка даты и времени</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="20"/>
+        <source>Time</source>
+        <translation>Время</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="26"/>
+        <source>&amp;Show seconds</source>
+        <translation>&amp;Показывать секунды</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="33"/>
+        <source>12 &amp;hour style</source>
+        <translation>12-&amp;часовой формат</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="40"/>
+        <source>&amp;Use UTC</source>
+        <translation>&amp;Использовать UTC</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="50"/>
+        <source>Date</source>
+        <translation>Дата</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="59"/>
+        <source>Date &amp;format</source>
+        <translation>Ф&amp;ормат даты</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="76"/>
+        <source>&amp;Do not show date</source>
+        <translation>&amp;Не показывать дату</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="86"/>
+        <source>Show date &amp;before time</source>
+        <translation>Показывать дату &amp;перед временем</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="93"/>
+        <source>Show date &amp;after time</source>
+        <translation>Показывать дату &amp;после времени</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="100"/>
+        <source>Show date below time on new &amp;line</source>
+        <translation>Показывать дату под временем новой &amp;строкой</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="107"/>
+        <source>First day of week in calendar</source>
+        <translation>Первый день недели в календаре</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="124"/>
+        <source>Orientation</source>
+        <translation>Ориентация</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="130"/>
+        <source>Auto&amp;rotate when the panel is vertical</source>
+        <translation>Авто&amp;поворот для вертикальной панели</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Input custom date format</source>
+        <translation>Введите свой формат даты</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Interpreted sequences of date format are:
+
+d	the day as number without a leading zero (1 to 31)
+dd	the day as number with a leading zero (01 to 31)
+ddd	the abbreviated localized day name (e.g. &apos;Mon&apos; to &apos;Sun&apos;).
+dddd	the long localized day name (e.g. &apos;Monday&apos; to &apos;Sunday&apos;).
+M	the month as number without a leading zero (1-12)
+MM	the month as number with a leading zero (01-12)
+MMM	the abbreviated localized month name (e.g. &apos;Jan&apos; to &apos;Dec&apos;).
+MMMM	the long localized month name (e.g. &apos;January&apos; to &apos;December&apos;).
+yy	the year as two digit number (00-99)
+yyyy	the year as four digit number
+
+All other input characters will be treated as text.
+Any sequence of characters that are enclosed in single quotes (&apos;)
+will also be treated as text and not be used as an expression.
+
+
+Custom date format:</source>
+        <translation>Интерпретация последовательностей формата даты:
+
+d	день как число без ноля перед ним (от 1 до 31)
+dd	день как число с нолём перед ним (от 01 до 31)
+ddd	аббревиатура названия дня недели (от «Пн» к «Вс»).
+dddd	полное название дня недели (от «Понедельник» к «Воскресенье»).
+M	месяц как число без ноля перед ним (от 1 до 12)
+MM	месяц как число с нолём перед ним (от 01 до 12)
+MMM	аббревиатура названия месяца (от «Янв» до «Дек»).
+MMMM	полное название месяца (от «Январь» до «Декабрь»).
+yy	год как двухразрядное число (00-99)
+yyyy	год как четырёхразрядное число
+
+Все прочие введёные знаки будут обработаны как текст.
+Любая последовательность знаков, заключённая в одинарные кавычки (&apos;),
+также будет обработана как текст и не будет использована в выражении.
+
+
+Свой формат даты:</translation>
+    </message>
+</context>
+</TS>

--- a/lxqt-panel/plugin-clock/clock_sk_SK.ts
+++ b/lxqt-panel/plugin-clock/clock_sk_SK.ts
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sk_SK">
+<context>
+    <name>FirstDayCombo</name>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="49"/>
+        <source>&lt;locale based&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClock</name>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="57"/>
+        <source>Date&amp;Time (clock) plugin is deprecated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="58"/>
+        <source>The &lt;strong&gt;clock&lt;/strong&gt; plugin is deprecated and will be removed in future version of LXQt. Consider replacing it with &lt;strong&gt;worldclock&lt;/strong&gt;.&lt;br/&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="60"/>
+        <source>don&apos;t show this again</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClockConfiguration</name>
+    <message>
+        <source>LXQt Clock Settings</source>
+        <translation type="vanished">Nastavenia hodín prostredia LXQt</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="14"/>
+        <source>Clock Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="20"/>
+        <source>Time</source>
+        <translation>Čas</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="26"/>
+        <source>&amp;Show seconds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="33"/>
+        <source>12 &amp;hour style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="40"/>
+        <source>&amp;Use UTC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="59"/>
+        <source>Date &amp;format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="76"/>
+        <source>&amp;Do not show date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="86"/>
+        <source>Show date &amp;before time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="93"/>
+        <source>Show date &amp;after time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="100"/>
+        <source>Show date below time on new &amp;line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="107"/>
+        <source>First day of week in calendar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="124"/>
+        <source>Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="130"/>
+        <source>Auto&amp;rotate when the panel is vertical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="50"/>
+        <source>Date</source>
+        <translation>Dátum</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Input custom date format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Interpreted sequences of date format are:
+
+d	the day as number without a leading zero (1 to 31)
+dd	the day as number with a leading zero (01 to 31)
+ddd	the abbreviated localized day name (e.g. &apos;Mon&apos; to &apos;Sun&apos;).
+dddd	the long localized day name (e.g. &apos;Monday&apos; to &apos;Sunday&apos;).
+M	the month as number without a leading zero (1-12)
+MM	the month as number with a leading zero (01-12)
+MMM	the abbreviated localized month name (e.g. &apos;Jan&apos; to &apos;Dec&apos;).
+MMMM	the long localized month name (e.g. &apos;January&apos; to &apos;December&apos;).
+yy	the year as two digit number (00-99)
+yyyy	the year as four digit number
+
+All other input characters will be treated as text.
+Any sequence of characters that are enclosed in single quotes (&apos;)
+will also be treated as text and not be used as an expression.
+
+
+Custom date format:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/lxqt-panel/plugin-clock/clock_sl.ts
+++ b/lxqt-panel/plugin-clock/clock_sl.ts
@@ -1,0 +1,199 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sl">
+<context>
+    <name>FirstDayCombo</name>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="49"/>
+        <source>&lt;locale based&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClock</name>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="57"/>
+        <source>Date&amp;Time (clock) plugin is deprecated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="58"/>
+        <source>The &lt;strong&gt;clock&lt;/strong&gt; plugin is deprecated and will be removed in future version of LXQt. Consider replacing it with &lt;strong&gt;worldclock&lt;/strong&gt;.&lt;br/&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="60"/>
+        <source>don&apos;t show this again</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClockConfiguration</name>
+    <message>
+        <source>LXQt Clock Settings</source>
+        <translation type="vanished">Nastavitve ure za LXQt</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="14"/>
+        <source>Clock Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="20"/>
+        <source>Time</source>
+        <translation>Čas</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="26"/>
+        <source>&amp;Show seconds</source>
+        <translation>Pokaži &amp;sekunde</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="33"/>
+        <source>12 &amp;hour style</source>
+        <translation>12-&amp;urni slog</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="40"/>
+        <source>&amp;Use UTC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="59"/>
+        <source>Date &amp;format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="76"/>
+        <source>&amp;Do not show date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="86"/>
+        <source>Show date &amp;before time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="93"/>
+        <source>Show date &amp;after time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="100"/>
+        <source>Show date below time on new &amp;line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="107"/>
+        <source>First day of week in calendar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="124"/>
+        <source>Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="130"/>
+        <source>Auto&amp;rotate when the panel is vertical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Font</source>
+        <translation type="vanished">&amp;Pisava</translation>
+    </message>
+    <message>
+        <source>Font</source>
+        <translation type="vanished">Pisava</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="50"/>
+        <source>Date</source>
+        <translation>Datum</translation>
+    </message>
+    <message>
+        <source>Show &amp;date</source>
+        <translation type="vanished">Pokaži &amp;datum</translation>
+    </message>
+    <message>
+        <source>D&amp;ate format</source>
+        <translation type="vanished">&amp;Oblika datuma</translation>
+    </message>
+    <message>
+        <source>Fon&amp;t</source>
+        <translation type="vanished">P&amp;isava</translation>
+    </message>
+    <message>
+        <source>Show date in &amp;new line</source>
+        <translation type="vanished">Pokaži datum v &amp;novi vrstici</translation>
+    </message>
+    <message>
+        <source>&amp;Use theme fonts</source>
+        <translation type="vanished">&amp;Uporabi pisavo teme</translation>
+    </message>
+    <message>
+        <source>Time font</source>
+        <translation type="vanished">Pisava za čas</translation>
+    </message>
+    <message>
+        <source>Date font</source>
+        <translation type="vanished">Pisava za datum</translation>
+    </message>
+    <message>
+        <source>Ultra light</source>
+        <translation type="vanished">Ultra lahko</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="vanished">Lahko</translation>
+    </message>
+    <message>
+        <source>Ultra black</source>
+        <translation type="vanished">Ultra krepko</translation>
+    </message>
+    <message>
+        <source>Black</source>
+        <translation type="vanished">Krepko</translation>
+    </message>
+    <message>
+        <source>Bold</source>
+        <translation type="vanished">Polkrepko</translation>
+    </message>
+    <message>
+        <source>Demi bold</source>
+        <translation type="vanished">Pol-polkrepko</translation>
+    </message>
+    <message>
+        <source>Italic</source>
+        <translation type="vanished">Ležeče</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Input custom date format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Interpreted sequences of date format are:
+
+d	the day as number without a leading zero (1 to 31)
+dd	the day as number with a leading zero (01 to 31)
+ddd	the abbreviated localized day name (e.g. &apos;Mon&apos; to &apos;Sun&apos;).
+dddd	the long localized day name (e.g. &apos;Monday&apos; to &apos;Sunday&apos;).
+M	the month as number without a leading zero (1-12)
+MM	the month as number with a leading zero (01-12)
+MMM	the abbreviated localized month name (e.g. &apos;Jan&apos; to &apos;Dec&apos;).
+MMMM	the long localized month name (e.g. &apos;January&apos; to &apos;December&apos;).
+yy	the year as two digit number (00-99)
+yyyy	the year as four digit number
+
+All other input characters will be treated as text.
+Any sequence of characters that are enclosed in single quotes (&apos;)
+will also be treated as text and not be used as an expression.
+
+
+Custom date format:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/lxqt-panel/plugin-clock/clock_sr@latin.ts
+++ b/lxqt-panel/plugin-clock/clock_sr@latin.ts
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sr@latin">
+<context>
+    <name>FirstDayCombo</name>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="49"/>
+        <source>&lt;locale based&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClock</name>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="57"/>
+        <source>Date&amp;Time (clock) plugin is deprecated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="58"/>
+        <source>The &lt;strong&gt;clock&lt;/strong&gt; plugin is deprecated and will be removed in future version of LXQt. Consider replacing it with &lt;strong&gt;worldclock&lt;/strong&gt;.&lt;br/&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="60"/>
+        <source>don&apos;t show this again</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClockConfiguration</name>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="14"/>
+        <source>Clock Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="20"/>
+        <source>Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="26"/>
+        <source>&amp;Show seconds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="33"/>
+        <source>12 &amp;hour style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="40"/>
+        <source>&amp;Use UTC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="59"/>
+        <source>Date &amp;format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="76"/>
+        <source>&amp;Do not show date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="86"/>
+        <source>Show date &amp;before time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="93"/>
+        <source>Show date &amp;after time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="100"/>
+        <source>Show date below time on new &amp;line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="107"/>
+        <source>First day of week in calendar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="124"/>
+        <source>Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="130"/>
+        <source>Auto&amp;rotate when the panel is vertical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="50"/>
+        <source>Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Input custom date format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Interpreted sequences of date format are:
+
+d	the day as number without a leading zero (1 to 31)
+dd	the day as number with a leading zero (01 to 31)
+ddd	the abbreviated localized day name (e.g. &apos;Mon&apos; to &apos;Sun&apos;).
+dddd	the long localized day name (e.g. &apos;Monday&apos; to &apos;Sunday&apos;).
+M	the month as number without a leading zero (1-12)
+MM	the month as number with a leading zero (01-12)
+MMM	the abbreviated localized month name (e.g. &apos;Jan&apos; to &apos;Dec&apos;).
+MMMM	the long localized month name (e.g. &apos;January&apos; to &apos;December&apos;).
+yy	the year as two digit number (00-99)
+yyyy	the year as four digit number
+
+All other input characters will be treated as text.
+Any sequence of characters that are enclosed in single quotes (&apos;)
+will also be treated as text and not be used as an expression.
+
+
+Custom date format:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/lxqt-panel/plugin-clock/clock_sr_BA.ts
+++ b/lxqt-panel/plugin-clock/clock_sr_BA.ts
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sr_BA">
+<context>
+    <name>FirstDayCombo</name>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="49"/>
+        <source>&lt;locale based&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClock</name>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="57"/>
+        <source>Date&amp;Time (clock) plugin is deprecated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="58"/>
+        <source>The &lt;strong&gt;clock&lt;/strong&gt; plugin is deprecated and will be removed in future version of LXQt. Consider replacing it with &lt;strong&gt;worldclock&lt;/strong&gt;.&lt;br/&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="60"/>
+        <source>don&apos;t show this again</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClockConfiguration</name>
+    <message>
+        <source>LXQt Clock Settings</source>
+        <translation type="vanished">Подешавање Рејзоровог сата</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="14"/>
+        <source>Clock Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="20"/>
+        <source>Time</source>
+        <translation>Вријеме</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="26"/>
+        <source>&amp;Show seconds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="33"/>
+        <source>12 &amp;hour style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="40"/>
+        <source>&amp;Use UTC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="59"/>
+        <source>Date &amp;format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="76"/>
+        <source>&amp;Do not show date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="86"/>
+        <source>Show date &amp;before time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="93"/>
+        <source>Show date &amp;after time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="100"/>
+        <source>Show date below time on new &amp;line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="107"/>
+        <source>First day of week in calendar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="124"/>
+        <source>Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="130"/>
+        <source>Auto&amp;rotate when the panel is vertical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show seconds</source>
+        <translation type="vanished">Прикажи секунде</translation>
+    </message>
+    <message>
+        <source>12 hour style</source>
+        <translation type="vanished">12-часовни сат</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="50"/>
+        <source>Date</source>
+        <translation>Датум</translation>
+    </message>
+    <message>
+        <source>Show date</source>
+        <translation type="vanished">Прикажи датум</translation>
+    </message>
+    <message>
+        <source>Show date in new line</source>
+        <translation type="vanished">Прикажи датум у новој линији</translation>
+    </message>
+    <message>
+        <source>Date format</source>
+        <translation type="vanished">Формат датума</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Input custom date format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Interpreted sequences of date format are:
+
+d	the day as number without a leading zero (1 to 31)
+dd	the day as number with a leading zero (01 to 31)
+ddd	the abbreviated localized day name (e.g. &apos;Mon&apos; to &apos;Sun&apos;).
+dddd	the long localized day name (e.g. &apos;Monday&apos; to &apos;Sunday&apos;).
+M	the month as number without a leading zero (1-12)
+MM	the month as number with a leading zero (01-12)
+MMM	the abbreviated localized month name (e.g. &apos;Jan&apos; to &apos;Dec&apos;).
+MMMM	the long localized month name (e.g. &apos;January&apos; to &apos;December&apos;).
+yy	the year as two digit number (00-99)
+yyyy	the year as four digit number
+
+All other input characters will be treated as text.
+Any sequence of characters that are enclosed in single quotes (&apos;)
+will also be treated as text and not be used as an expression.
+
+
+Custom date format:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/lxqt-panel/plugin-clock/clock_sr_RS.ts
+++ b/lxqt-panel/plugin-clock/clock_sr_RS.ts
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sr_RS">
+<context>
+    <name>FirstDayCombo</name>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="49"/>
+        <source>&lt;locale based&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClock</name>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="57"/>
+        <source>Date&amp;Time (clock) plugin is deprecated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="58"/>
+        <source>The &lt;strong&gt;clock&lt;/strong&gt; plugin is deprecated and will be removed in future version of LXQt. Consider replacing it with &lt;strong&gt;worldclock&lt;/strong&gt;.&lt;br/&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="60"/>
+        <source>don&apos;t show this again</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClockConfiguration</name>
+    <message>
+        <source>LXQt Clock Settings</source>
+        <translation type="vanished">Подешавање Рејзоровог сата</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="14"/>
+        <source>Clock Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="20"/>
+        <source>Time</source>
+        <translation>Време</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="26"/>
+        <source>&amp;Show seconds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="33"/>
+        <source>12 &amp;hour style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="40"/>
+        <source>&amp;Use UTC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="59"/>
+        <source>Date &amp;format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="76"/>
+        <source>&amp;Do not show date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="86"/>
+        <source>Show date &amp;before time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="93"/>
+        <source>Show date &amp;after time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="100"/>
+        <source>Show date below time on new &amp;line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="107"/>
+        <source>First day of week in calendar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="124"/>
+        <source>Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="130"/>
+        <source>Auto&amp;rotate when the panel is vertical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="50"/>
+        <source>Date</source>
+        <translation>Датум</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Input custom date format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Interpreted sequences of date format are:
+
+d	the day as number without a leading zero (1 to 31)
+dd	the day as number with a leading zero (01 to 31)
+ddd	the abbreviated localized day name (e.g. &apos;Mon&apos; to &apos;Sun&apos;).
+dddd	the long localized day name (e.g. &apos;Monday&apos; to &apos;Sunday&apos;).
+M	the month as number without a leading zero (1-12)
+MM	the month as number with a leading zero (01-12)
+MMM	the abbreviated localized month name (e.g. &apos;Jan&apos; to &apos;Dec&apos;).
+MMMM	the long localized month name (e.g. &apos;January&apos; to &apos;December&apos;).
+yy	the year as two digit number (00-99)
+yyyy	the year as four digit number
+
+All other input characters will be treated as text.
+Any sequence of characters that are enclosed in single quotes (&apos;)
+will also be treated as text and not be used as an expression.
+
+
+Custom date format:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/lxqt-panel/plugin-clock/clock_th_TH.ts
+++ b/lxqt-panel/plugin-clock/clock_th_TH.ts
@@ -1,0 +1,199 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="th_TH">
+<context>
+    <name>FirstDayCombo</name>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="49"/>
+        <source>&lt;locale based&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClock</name>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="57"/>
+        <source>Date&amp;Time (clock) plugin is deprecated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="58"/>
+        <source>The &lt;strong&gt;clock&lt;/strong&gt; plugin is deprecated and will be removed in future version of LXQt. Consider replacing it with &lt;strong&gt;worldclock&lt;/strong&gt;.&lt;br/&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="60"/>
+        <source>don&apos;t show this again</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClockConfiguration</name>
+    <message>
+        <source>LXQt Clock Settings</source>
+        <translation type="vanished">ค่าตั้งนาฬิกา LXQt</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="14"/>
+        <source>Clock Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="20"/>
+        <source>Time</source>
+        <translation>เวลา</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="26"/>
+        <source>&amp;Show seconds</source>
+        <translation>แ&amp;สดงวินาที</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="33"/>
+        <source>12 &amp;hour style</source>
+        <translation>รูปแบบ 12 ชั่วโ&amp;มง</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="40"/>
+        <source>&amp;Use UTC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="59"/>
+        <source>Date &amp;format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="76"/>
+        <source>&amp;Do not show date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="86"/>
+        <source>Show date &amp;before time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="93"/>
+        <source>Show date &amp;after time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="100"/>
+        <source>Show date below time on new &amp;line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="107"/>
+        <source>First day of week in calendar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="124"/>
+        <source>Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="130"/>
+        <source>Auto&amp;rotate when the panel is vertical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Font</source>
+        <translation type="vanished">แบบอั&amp;กษร</translation>
+    </message>
+    <message>
+        <source>Font</source>
+        <translation type="vanished">แบบอักษร</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="50"/>
+        <source>Date</source>
+        <translation>วันที่</translation>
+    </message>
+    <message>
+        <source>Show &amp;date</source>
+        <translation type="vanished">แสดง&amp;เวลา</translation>
+    </message>
+    <message>
+        <source>D&amp;ate format</source>
+        <translation type="vanished">รูปแ&amp;บบวันที่</translation>
+    </message>
+    <message>
+        <source>Fon&amp;t</source>
+        <translation type="vanished">แบบอักษ&amp;ร</translation>
+    </message>
+    <message>
+        <source>Show date in &amp;new line</source>
+        <translation type="vanished">แสดงวันที่ในบรรทัดใ&amp;หม่</translation>
+    </message>
+    <message>
+        <source>&amp;Use theme fonts</source>
+        <translation type="vanished">&amp;ใช้แบบอักษรของชุดตกแต่ง</translation>
+    </message>
+    <message>
+        <source>Time font</source>
+        <translation type="vanished">แบบอักษรของเวลา</translation>
+    </message>
+    <message>
+        <source>Date font</source>
+        <translation type="vanished">แบบอักษรของวันที่</translation>
+    </message>
+    <message>
+        <source>Ultra light</source>
+        <translation type="vanished">สว่างจ้า</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="vanished">สว่าง</translation>
+    </message>
+    <message>
+        <source>Ultra black</source>
+        <translation type="vanished">ดำมืด</translation>
+    </message>
+    <message>
+        <source>Black</source>
+        <translation type="vanished">ดำ</translation>
+    </message>
+    <message>
+        <source>Bold</source>
+        <translation type="vanished">ตัวหนา</translation>
+    </message>
+    <message>
+        <source>Demi bold</source>
+        <translation type="vanished">ตัวกึ่งหนา</translation>
+    </message>
+    <message>
+        <source>Italic</source>
+        <translation type="vanished">ตัวเอียง</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Input custom date format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Interpreted sequences of date format are:
+
+d	the day as number without a leading zero (1 to 31)
+dd	the day as number with a leading zero (01 to 31)
+ddd	the abbreviated localized day name (e.g. &apos;Mon&apos; to &apos;Sun&apos;).
+dddd	the long localized day name (e.g. &apos;Monday&apos; to &apos;Sunday&apos;).
+M	the month as number without a leading zero (1-12)
+MM	the month as number with a leading zero (01-12)
+MMM	the abbreviated localized month name (e.g. &apos;Jan&apos; to &apos;Dec&apos;).
+MMMM	the long localized month name (e.g. &apos;January&apos; to &apos;December&apos;).
+yy	the year as two digit number (00-99)
+yyyy	the year as four digit number
+
+All other input characters will be treated as text.
+Any sequence of characters that are enclosed in single quotes (&apos;)
+will also be treated as text and not be used as an expression.
+
+
+Custom date format:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/lxqt-panel/plugin-clock/clock_tr.ts
+++ b/lxqt-panel/plugin-clock/clock_tr.ts
@@ -1,0 +1,199 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="tr">
+<context>
+    <name>FirstDayCombo</name>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="49"/>
+        <source>&lt;locale based&gt;</source>
+        <translation>&lt;Yerele bağlı&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClock</name>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="57"/>
+        <source>Date&amp;Time (clock) plugin is deprecated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="58"/>
+        <source>The &lt;strong&gt;clock&lt;/strong&gt; plugin is deprecated and will be removed in future version of LXQt. Consider replacing it with &lt;strong&gt;worldclock&lt;/strong&gt;.&lt;br/&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="60"/>
+        <source>don&apos;t show this again</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClockConfiguration</name>
+    <message>
+        <source>LXQt Clock Settings</source>
+        <translation type="vanished">LXQt Saat Ayarları</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="14"/>
+        <source>Clock Settings</source>
+        <translation>Saat Ayarları</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="20"/>
+        <source>Time</source>
+        <translation>Zaman</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="26"/>
+        <source>&amp;Show seconds</source>
+        <translation>&amp;Saniyeyi göster</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="33"/>
+        <source>12 &amp;hour style</source>
+        <translation>12 saatlik &amp;gösterim biçimi</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="40"/>
+        <source>&amp;Use UTC</source>
+        <translation>&amp;UTC dilimini kullan</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="59"/>
+        <source>Date &amp;format</source>
+        <translation>Tarih &amp;biçimi</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="76"/>
+        <source>&amp;Do not show date</source>
+        <translation>Tarihi göster&amp;me</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="86"/>
+        <source>Show date &amp;before time</source>
+        <translation>Tarihi saatten &amp;önce göster</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="93"/>
+        <source>Show date &amp;after time</source>
+        <translation>Tarihi saatten sonr&amp;a göster</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="100"/>
+        <source>Show date below time on new &amp;line</source>
+        <translation>Tarihi saatin a&amp;ltında yeni bir satırda göster</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="107"/>
+        <source>First day of week in calendar</source>
+        <translation>Haftanın ilk günü</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="124"/>
+        <source>Orientation</source>
+        <translation>Yönlendirme</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="130"/>
+        <source>Auto&amp;rotate when the panel is vertical</source>
+        <translation>Panel dikey olduğunda otomatik yönlendi&amp;r</translation>
+    </message>
+    <message>
+        <source>&amp;Font</source>
+        <translation type="vanished">&amp;Yazı tipi</translation>
+    </message>
+    <message>
+        <source>Font</source>
+        <translation type="vanished">Yazı Tipi</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="50"/>
+        <source>Date</source>
+        <translation>Tarih</translation>
+    </message>
+    <message>
+        <source>Show &amp;date</source>
+        <translation type="vanished">Tarihi gö&amp;ster</translation>
+    </message>
+    <message>
+        <source>D&amp;ate format</source>
+        <translation type="vanished">T&amp;arih biçimi</translation>
+    </message>
+    <message>
+        <source>Fon&amp;t</source>
+        <translation type="vanished">Yazı &amp;Tipi</translation>
+    </message>
+    <message>
+        <source>Show date in &amp;new line</source>
+        <translation type="vanished">Tarihi &amp;yeni satırda göster</translation>
+    </message>
+    <message>
+        <source>&amp;Use theme fonts</source>
+        <translation type="vanished">&amp;Tema yazıtipini kullan</translation>
+    </message>
+    <message>
+        <source>Time font</source>
+        <translation type="vanished">Zaman yazı tipi</translation>
+    </message>
+    <message>
+        <source>Date font</source>
+        <translation type="vanished">Tarih yazıtipi</translation>
+    </message>
+    <message>
+        <source>Ultra light</source>
+        <translation type="vanished">Aşırı ince</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="vanished">Hafif</translation>
+    </message>
+    <message>
+        <source>Ultra black</source>
+        <translation type="vanished">Aşırı siyah</translation>
+    </message>
+    <message>
+        <source>Black</source>
+        <translation type="vanished">Siyah</translation>
+    </message>
+    <message>
+        <source>Bold</source>
+        <translation type="vanished">Koyu</translation>
+    </message>
+    <message>
+        <source>Demi bold</source>
+        <translation type="vanished">Yarı koyu</translation>
+    </message>
+    <message>
+        <source>Italic</source>
+        <translation type="vanished">Eğik</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Input custom date format</source>
+        <translation>Özel tarih biçimi girin</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Interpreted sequences of date format are:
+
+d	the day as number without a leading zero (1 to 31)
+dd	the day as number with a leading zero (01 to 31)
+ddd	the abbreviated localized day name (e.g. &apos;Mon&apos; to &apos;Sun&apos;).
+dddd	the long localized day name (e.g. &apos;Monday&apos; to &apos;Sunday&apos;).
+M	the month as number without a leading zero (1-12)
+MM	the month as number with a leading zero (01-12)
+MMM	the abbreviated localized month name (e.g. &apos;Jan&apos; to &apos;Dec&apos;).
+MMMM	the long localized month name (e.g. &apos;January&apos; to &apos;December&apos;).
+yy	the year as two digit number (00-99)
+yyyy	the year as four digit number
+
+All other input characters will be treated as text.
+Any sequence of characters that are enclosed in single quotes (&apos;)
+will also be treated as text and not be used as an expression.
+
+
+Custom date format:</source>
+        <translation></translation>
+    </message>
+</context>
+</TS>

--- a/lxqt-panel/plugin-clock/clock_uk.ts
+++ b/lxqt-panel/plugin-clock/clock_uk.ts
@@ -1,0 +1,217 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="uk">
+<context>
+    <name>FirstDayCombo</name>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="49"/>
+        <source>&lt;locale based&gt;</source>
+        <translation>&lt;базується на локалі&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClock</name>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="57"/>
+        <source>Date&amp;Time (clock) plugin is deprecated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="58"/>
+        <source>The &lt;strong&gt;clock&lt;/strong&gt; plugin is deprecated and will be removed in future version of LXQt. Consider replacing it with &lt;strong&gt;worldclock&lt;/strong&gt;.&lt;br/&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="60"/>
+        <source>don&apos;t show this again</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClockConfiguration</name>
+    <message>
+        <source>LXQt Clock Settings</source>
+        <translation type="vanished">Налаштування годинника LXQt</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="14"/>
+        <source>Clock Settings</source>
+        <translation>Налаштування годинника</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="20"/>
+        <source>Time</source>
+        <translation>Час</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="26"/>
+        <source>&amp;Show seconds</source>
+        <translation>Показувати &amp;секунди</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="33"/>
+        <source>12 &amp;hour style</source>
+        <translation>12-&amp;годинний стиль</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="40"/>
+        <source>&amp;Use UTC</source>
+        <translation>&amp;Використати UTC</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="59"/>
+        <source>Date &amp;format</source>
+        <translation>Формат д&amp;ати</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="76"/>
+        <source>&amp;Do not show date</source>
+        <translation>&amp;Не показувати дату</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="86"/>
+        <source>Show date &amp;before time</source>
+        <translation>Показувати дату &amp;перед часом</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="93"/>
+        <source>Show date &amp;after time</source>
+        <translation>Показувати дату пі&amp;сля часу</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="100"/>
+        <source>Show date below time on new &amp;line</source>
+        <translation>Показати дату під часом в новій &amp;лінійці </translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="107"/>
+        <source>First day of week in calendar</source>
+        <translation>Перший день тижна в календарі</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="124"/>
+        <source>Orientation</source>
+        <translation>Орієнтація</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="130"/>
+        <source>Auto&amp;rotate when the panel is vertical</source>
+        <translation>Автоповертання коли панель є вертикальна</translation>
+    </message>
+    <message>
+        <source>&amp;Font</source>
+        <translation type="vanished">&amp;Шрифт</translation>
+    </message>
+    <message>
+        <source>Font</source>
+        <translation type="vanished">Шрифт</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="50"/>
+        <source>Date</source>
+        <translation>Дата</translation>
+    </message>
+    <message>
+        <source>Show &amp;date</source>
+        <translation type="vanished">Показувати &amp;дату</translation>
+    </message>
+    <message>
+        <source>D&amp;ate format</source>
+        <translation type="vanished">Формат д&amp;ати</translation>
+    </message>
+    <message>
+        <source>Fon&amp;t</source>
+        <translation type="vanished">Шриф&amp;т</translation>
+    </message>
+    <message>
+        <source>Show date in &amp;new line</source>
+        <translation type="vanished">Показувати дату в &amp;новому рядку</translation>
+    </message>
+    <message>
+        <source>&amp;Use theme fonts</source>
+        <translation type="vanished">&amp;Використовувати шрифти з теми</translation>
+    </message>
+    <message>
+        <source>Time font</source>
+        <translation type="vanished">Шрифт часу</translation>
+    </message>
+    <message>
+        <source>Date font</source>
+        <translation type="vanished">Шрифт дати</translation>
+    </message>
+    <message>
+        <source>Ultra light</source>
+        <translation type="vanished">Надтонкий</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="vanished">Тонкий</translation>
+    </message>
+    <message>
+        <source>Ultra black</source>
+        <translation type="vanished">Дуже темний</translation>
+    </message>
+    <message>
+        <source>Black</source>
+        <translation type="vanished">Темний</translation>
+    </message>
+    <message>
+        <source>Bold</source>
+        <translation type="vanished">Жирний</translation>
+    </message>
+    <message>
+        <source>Demi bold</source>
+        <translation type="vanished">Напівжирний</translation>
+    </message>
+    <message>
+        <source>Italic</source>
+        <translation type="vanished">Нахилений</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Input custom date format</source>
+        <translation>Введіть власний формат дати</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Interpreted sequences of date format are:
+
+d	the day as number without a leading zero (1 to 31)
+dd	the day as number with a leading zero (01 to 31)
+ddd	the abbreviated localized day name (e.g. &apos;Mon&apos; to &apos;Sun&apos;).
+dddd	the long localized day name (e.g. &apos;Monday&apos; to &apos;Sunday&apos;).
+M	the month as number without a leading zero (1-12)
+MM	the month as number with a leading zero (01-12)
+MMM	the abbreviated localized month name (e.g. &apos;Jan&apos; to &apos;Dec&apos;).
+MMMM	the long localized month name (e.g. &apos;January&apos; to &apos;December&apos;).
+yy	the year as two digit number (00-99)
+yyyy	the year as four digit number
+
+All other input characters will be treated as text.
+Any sequence of characters that are enclosed in single quotes (&apos;)
+will also be treated as text and not be used as an expression.
+
+
+Custom date format:</source>
+        <translation>Розпізнавальні комбінації формату дати є наступні:
+
+d	день числом без нуля (1 to 31)
+dd	день числом з нулем (01 to 31)
+ddd	абревіатура локалізованої назви дня (наприклад &apos;Пон&apos; до &apos;Нед&apos;).
+dddd	довга локалізована назва дня (наприклад &apos;Понеділок&apos; до &apos;Неділя&apos;).
+M	місяць числом без нуля (1-12)
+MM	місяць числом з нулем (01-12)
+MMM	абревіатура локалізованої назви місяця (наприклад &apos;Січ&apos; до &apos;Груд&apos;).
+MMMM	довга локалізована назва місяця (наприклад &apos;Січень&apos; до &apos;Грудень&apos;).
+yy	рік двома цифрами (00-99)
+yyyy	рік чотирма цифрами
+
+Всі інші вхідні символи трактуються як текст.
+Всі комбінації символів, що поміщені в одинарні лапки (&apos;)
+будуть теж трактуватися як текст і не будуть використовуватися у виразі.
+
+
+Власний формат дати:</translation>
+    </message>
+</context>
+</TS>

--- a/lxqt-panel/plugin-clock/clock_zh_CN.ts
+++ b/lxqt-panel/plugin-clock/clock_zh_CN.ts
@@ -1,0 +1,199 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_CN">
+<context>
+    <name>FirstDayCombo</name>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="49"/>
+        <source>&lt;locale based&gt;</source>
+        <translation></translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClock</name>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="57"/>
+        <source>Date&amp;Time (clock) plugin is deprecated</source>
+        <translation>不建议使用日期与时间（时钟）插件(&amp;T)</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="58"/>
+        <source>The &lt;strong&gt;clock&lt;/strong&gt; plugin is deprecated and will be removed in future version of LXQt. Consider replacing it with &lt;strong&gt;worldclock&lt;/strong&gt;.&lt;br/&gt;</source>
+        <translation>不建议您使用&lt;strong&gt;时钟&lt;/strong&gt;插件，且其将在未来版本的 LXQt 中移除。建议您改用&lt;strong&gt;世界时钟&lt;/strong&gt;。&lt;br/&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="60"/>
+        <source>don&apos;t show this again</source>
+        <translation>请勿再次显示</translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClockConfiguration</name>
+    <message>
+        <source>LXQt Clock Settings</source>
+        <translation type="vanished">LXQt时钟设置</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="14"/>
+        <source>Clock Settings</source>
+        <translation>时钟设置</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="20"/>
+        <source>Time</source>
+        <translation>时间</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="26"/>
+        <source>&amp;Show seconds</source>
+        <translation>显示秒(&amp;S)</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="33"/>
+        <source>12 &amp;hour style</source>
+        <translation>12小时样式(&amp;H)</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="40"/>
+        <source>&amp;Use UTC</source>
+        <translation>使用 UTC(&amp;U)</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="59"/>
+        <source>Date &amp;format</source>
+        <translation>时间格式(&amp;F)</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="76"/>
+        <source>&amp;Do not show date</source>
+        <translation>不显示日期(&amp;D)</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="86"/>
+        <source>Show date &amp;before time</source>
+        <translation>在时间左侧显示日期(&amp;B)</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="93"/>
+        <source>Show date &amp;after time</source>
+        <translation>在时间右侧显示日期(&amp;A)</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="100"/>
+        <source>Show date below time on new &amp;line</source>
+        <translation>在时间下面显示日期(&amp;L)</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="107"/>
+        <source>First day of week in calendar</source>
+        <translation>一周的第一天</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="124"/>
+        <source>Orientation</source>
+        <translation>方向</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="130"/>
+        <source>Auto&amp;rotate when the panel is vertical</source>
+        <translation>纵置面板时自动旋转(&amp;R)</translation>
+    </message>
+    <message>
+        <source>&amp;Font</source>
+        <translation type="vanished">字体(&amp;F)</translation>
+    </message>
+    <message>
+        <source>Font</source>
+        <translation type="vanished">字体</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="50"/>
+        <source>Date</source>
+        <translation>日期</translation>
+    </message>
+    <message>
+        <source>Show &amp;date</source>
+        <translation type="vanished">显示日期(&amp;D)</translation>
+    </message>
+    <message>
+        <source>D&amp;ate format</source>
+        <translation type="vanished">日期格式(&amp;A)</translation>
+    </message>
+    <message>
+        <source>Fon&amp;t</source>
+        <translation type="vanished">字体(&amp;T)</translation>
+    </message>
+    <message>
+        <source>Show date in &amp;new line</source>
+        <translation type="vanished">在新行显示日期(&amp;N)</translation>
+    </message>
+    <message>
+        <source>&amp;Use theme fonts</source>
+        <translation type="vanished">使用主题字体(&amp;U)</translation>
+    </message>
+    <message>
+        <source>Time font</source>
+        <translation type="vanished">时间字体</translation>
+    </message>
+    <message>
+        <source>Date font</source>
+        <translation type="vanished">日期字体</translation>
+    </message>
+    <message>
+        <source>Ultra light</source>
+        <translation type="vanished">超亮</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="vanished">亮</translation>
+    </message>
+    <message>
+        <source>Ultra black</source>
+        <translation type="vanished">超黑</translation>
+    </message>
+    <message>
+        <source>Black</source>
+        <translation type="vanished">黑</translation>
+    </message>
+    <message>
+        <source>Bold</source>
+        <translation type="vanished">黑体</translation>
+    </message>
+    <message>
+        <source>Demi bold</source>
+        <translation type="vanished">半粗体</translation>
+    </message>
+    <message>
+        <source>Italic</source>
+        <translation type="vanished">斜体</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Input custom date format</source>
+        <translation>输入自定义日期格式</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Interpreted sequences of date format are:
+
+d	the day as number without a leading zero (1 to 31)
+dd	the day as number with a leading zero (01 to 31)
+ddd	the abbreviated localized day name (e.g. &apos;Mon&apos; to &apos;Sun&apos;).
+dddd	the long localized day name (e.g. &apos;Monday&apos; to &apos;Sunday&apos;).
+M	the month as number without a leading zero (1-12)
+MM	the month as number with a leading zero (01-12)
+MMM	the abbreviated localized month name (e.g. &apos;Jan&apos; to &apos;Dec&apos;).
+MMMM	the long localized month name (e.g. &apos;January&apos; to &apos;December&apos;).
+yy	the year as two digit number (00-99)
+yyyy	the year as four digit number
+
+All other input characters will be treated as text.
+Any sequence of characters that are enclosed in single quotes (&apos;)
+will also be treated as text and not be used as an expression.
+
+
+Custom date format:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/lxqt-panel/plugin-clock/clock_zh_TW.ts
+++ b/lxqt-panel/plugin-clock/clock_zh_TW.ts
@@ -1,0 +1,199 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_TW">
+<context>
+    <name>FirstDayCombo</name>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="49"/>
+        <source>&lt;locale based&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClock</name>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="57"/>
+        <source>Date&amp;Time (clock) plugin is deprecated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="58"/>
+        <source>The &lt;strong&gt;clock&lt;/strong&gt; plugin is deprecated and will be removed in future version of LXQt. Consider replacing it with &lt;strong&gt;worldclock&lt;/strong&gt;.&lt;br/&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclock.cpp" line="60"/>
+        <source>don&apos;t show this again</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LXQtClockConfiguration</name>
+    <message>
+        <source>LXQt Clock Settings</source>
+        <translation type="vanished">LXQt時鐘設定</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="14"/>
+        <source>Clock Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="20"/>
+        <source>Time</source>
+        <translation>時間</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="26"/>
+        <source>&amp;Show seconds</source>
+        <translation>顯示秒(&amp;S)</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="33"/>
+        <source>12 &amp;hour style</source>
+        <translation>十二小時制(&amp;h)</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="40"/>
+        <source>&amp;Use UTC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="59"/>
+        <source>Date &amp;format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="76"/>
+        <source>&amp;Do not show date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="86"/>
+        <source>Show date &amp;before time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="93"/>
+        <source>Show date &amp;after time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="100"/>
+        <source>Show date below time on new &amp;line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="107"/>
+        <source>First day of week in calendar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="124"/>
+        <source>Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="130"/>
+        <source>Auto&amp;rotate when the panel is vertical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Font</source>
+        <translation type="vanished">字體(&amp;F)</translation>
+    </message>
+    <message>
+        <source>Font</source>
+        <translation type="vanished">字體</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.ui" line="50"/>
+        <source>Date</source>
+        <translation>日期</translation>
+    </message>
+    <message>
+        <source>Show &amp;date</source>
+        <translation type="vanished">顯示日期(&amp;d)</translation>
+    </message>
+    <message>
+        <source>D&amp;ate format</source>
+        <translation type="vanished">日期格式(&amp;a)</translation>
+    </message>
+    <message>
+        <source>Fon&amp;t</source>
+        <translation type="vanished">字體(&amp;t)</translation>
+    </message>
+    <message>
+        <source>Show date in &amp;new line</source>
+        <translation type="vanished">日期顯示在下一行中</translation>
+    </message>
+    <message>
+        <source>&amp;Use theme fonts</source>
+        <translation type="vanished">使用主題預設字體(&amp;U)</translation>
+    </message>
+    <message>
+        <source>Time font</source>
+        <translation type="vanished">時間的字體</translation>
+    </message>
+    <message>
+        <source>Date font</source>
+        <translation type="vanished">日期的字體</translation>
+    </message>
+    <message>
+        <source>Ultra light</source>
+        <translation type="vanished">極亮</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="vanished">亮</translation>
+    </message>
+    <message>
+        <source>Ultra black</source>
+        <translation type="vanished">極暗</translation>
+    </message>
+    <message>
+        <source>Black</source>
+        <translation type="vanished">暗</translation>
+    </message>
+    <message>
+        <source>Bold</source>
+        <translation type="vanished">粗體</translation>
+    </message>
+    <message>
+        <source>Demi bold</source>
+        <translation type="vanished">半粗體</translation>
+    </message>
+    <message>
+        <source>Italic</source>
+        <translation type="vanished">斜體</translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Input custom date format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../../lxqtclockconfiguration.cpp" line="268"/>
+        <source>Interpreted sequences of date format are:
+
+d	the day as number without a leading zero (1 to 31)
+dd	the day as number with a leading zero (01 to 31)
+ddd	the abbreviated localized day name (e.g. &apos;Mon&apos; to &apos;Sun&apos;).
+dddd	the long localized day name (e.g. &apos;Monday&apos; to &apos;Sunday&apos;).
+M	the month as number without a leading zero (1-12)
+MM	the month as number with a leading zero (01-12)
+MMM	the abbreviated localized month name (e.g. &apos;Jan&apos; to &apos;Dec&apos;).
+MMMM	the long localized month name (e.g. &apos;January&apos; to &apos;December&apos;).
+yy	the year as two digit number (00-99)
+yyyy	the year as four digit number
+
+All other input characters will be treated as text.
+Any sequence of characters that are enclosed in single quotes (&apos;)
+will also be treated as text and not be used as an expression.
+
+
+Custom date format:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
reverts the a bit early removal of the translations

fixes #352 
for the records - i don't care about a nice changelog in this case - we can consider lxqt-l10n deprecated and nearly dead